### PR TITLE
removed sgacl mandatory attribute

### DIFF
--- a/docs/resources/trustsec_egress_matrix_cell.md
+++ b/docs/resources/trustsec_egress_matrix_cell.md
@@ -15,6 +15,7 @@ This resource can manage a TrustSec Egress Matrix Cell.
 ```terraform
 resource "ise_trustsec_egress_matrix_cell" "example" {
   description        = "EgressMatrixCell Description"
+  default_rule       = "NONE"
   matrix_cell_status = "ENABLED"
   sgacls             = ["26b76b10-66e6-11ee-9cc1-9eb2a3ecc82a, 9d64dcd0-6384-11ee-9cc1-9eb2a3ecc82a"]
   source_sgt_id      = "93c66ed0-8c01-11e6-996c-525400b48521"
@@ -28,7 +29,6 @@ resource "ise_trustsec_egress_matrix_cell" "example" {
 ### Required
 
 - `destination_sgt_id` (String) Destination Trustsec Security Group ID
-- `sgacls` (List of String) List of TrustSec Security Groups ACLs
 - `source_sgt_id` (String) Source Trustsec Security Group ID
 
 ### Optional
@@ -40,6 +40,7 @@ resource "ise_trustsec_egress_matrix_cell" "example" {
 - `matrix_cell_status` (String) Matrix Cell Status
   - Choices: `DISABLED`, `ENABLED`, `MONITOR`
   - Default value: `DISABLED`
+- `sgacls` (List of String) List of TrustSec Security Groups ACLs
 
 ### Read-Only
 

--- a/examples/resources/ise_trustsec_egress_matrix_cell/resource.tf
+++ b/examples/resources/ise_trustsec_egress_matrix_cell/resource.tf
@@ -1,5 +1,6 @@
 resource "ise_trustsec_egress_matrix_cell" "example" {
   description        = "EgressMatrixCell Description"
+  default_rule       = "NONE"
   matrix_cell_status = "ENABLED"
   sgacls             = ["26b76b10-66e6-11ee-9cc1-9eb2a3ecc82a, 9d64dcd0-6384-11ee-9cc1-9eb2a3ecc82a"]
   source_sgt_id      = "93c66ed0-8c01-11e6-996c-525400b48521"

--- a/gen/definitions/trustsec_egress_matrix_cell.yaml
+++ b/gen/definitions/trustsec_egress_matrix_cell.yaml
@@ -15,9 +15,9 @@ attributes:
     type: String
     enum_values: [NONE, DENY_IP, PERMIT_IP]
     description: "Can be used only if sgacls not specified."
-    example: "PERMIT_IP"
+    example: "NONE"
     default_value: "NONE"
-    exclude_test: true
+    minimum_test_value: '"PERMIT_IP"'
   - model_name: matrixCellStatus
     data_path: [EgressMatrixCell]
     type: String
@@ -28,7 +28,6 @@ attributes:
   - model_name: sgacls
     data_path: [EgressMatrixCell]
     tf_name: sgacls
-    mandatory: true
     type: StringList
     test_value: "[ise_trustsec_security_group_acl.test.id]"
     description: List of TrustSec Security Groups ACLs

--- a/internal/provider/data_source_ise_trustsec_egress_matrix_cell_test.go
+++ b/internal/provider/data_source_ise_trustsec_egress_matrix_cell_test.go
@@ -32,6 +32,7 @@ import (
 func TestAccDataSourceIseTrustSecEgressMatrixCell(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_trustsec_egress_matrix_cell.test", "description", "EgressMatrixCell Description"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.ise_trustsec_egress_matrix_cell.test", "default_rule", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_trustsec_egress_matrix_cell.test", "matrix_cell_status", "ENABLED"))
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -72,6 +73,7 @@ resource "ise_trustsec_security_group_acl" "test" {
 func testAccDataSourceIseTrustSecEgressMatrixCellConfig() string {
 	config := `resource "ise_trustsec_egress_matrix_cell" "test" {` + "\n"
 	config += `	description = "EgressMatrixCell Description"` + "\n"
+	config += `	default_rule = "NONE"` + "\n"
 	config += `	matrix_cell_status = "ENABLED"` + "\n"
 	config += `	sgacls = [ise_trustsec_security_group_acl.test.id]` + "\n"
 	config += `	source_sgt_id = ise_trustsec_security_group.test.id` + "\n"

--- a/internal/provider/resource_ise_trustsec_egress_matrix_cell.go
+++ b/internal/provider/resource_ise_trustsec_egress_matrix_cell.go
@@ -97,7 +97,7 @@ func (r *TrustSecEgressMatrixCellResource) Schema(ctx context.Context, req resou
 			"sgacls": schema.ListAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("List of TrustSec Security Groups ACLs").String,
 				ElementType:         types.StringType,
-				Required:            true,
+				Optional:            true,
 			},
 			"source_sgt_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Source Trustsec Security Group ID").String,

--- a/internal/provider/resource_ise_trustsec_egress_matrix_cell_test.go
+++ b/internal/provider/resource_ise_trustsec_egress_matrix_cell_test.go
@@ -33,6 +33,7 @@ import (
 func TestAccIseTrustSecEgressMatrixCell(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("ise_trustsec_egress_matrix_cell.test", "description", "EgressMatrixCell Description"))
+	checks = append(checks, resource.TestCheckResourceAttr("ise_trustsec_egress_matrix_cell.test", "default_rule", "NONE"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_trustsec_egress_matrix_cell.test", "matrix_cell_status", "ENABLED"))
 
 	var steps []resource.TestStep
@@ -83,7 +84,7 @@ resource "ise_trustsec_security_group_acl" "test" {
 //template:begin testAccConfigMinimal
 func testAccIseTrustSecEgressMatrixCellConfig_minimum() string {
 	config := `resource "ise_trustsec_egress_matrix_cell" "test" {` + "\n"
-	config += `	sgacls = [ise_trustsec_security_group_acl.test.id]` + "\n"
+	config += `	default_rule = "PERMIT_IP"` + "\n"
 	config += `	source_sgt_id = ise_trustsec_security_group.test.id` + "\n"
 	config += `	destination_sgt_id = ise_trustsec_security_group.test.id` + "\n"
 	config += `}` + "\n"
@@ -96,6 +97,7 @@ func testAccIseTrustSecEgressMatrixCellConfig_minimum() string {
 func testAccIseTrustSecEgressMatrixCellConfig_all() string {
 	config := `resource "ise_trustsec_egress_matrix_cell" "test" {` + "\n"
 	config += `	description = "EgressMatrixCell Description"` + "\n"
+	config += `	default_rule = "NONE"` + "\n"
 	config += `	matrix_cell_status = "ENABLED"` + "\n"
 	config += `	sgacls = [ise_trustsec_security_group_acl.test.id]` + "\n"
 	config += `	source_sgt_id = ise_trustsec_security_group.test.id` + "\n"


### PR DESCRIPTION
sgacl attribute is not needed if default_rule PERMIT_IP or DENY_IP is used