### PR TITLE
removed mandatory attribute from groupId in endpoint resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 (unreleased)
+
+- Make `groupId` attribute of `ise_endpoint` resource optional
+
 ## 0.2.0
 
 - Add `ise_endpoint` resource and data source

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.2.1 (unreleased)
+
+- Make `groupId` attribute of `ise_endpoint` resource optional
+
 ## 0.2.0
 
 - Add `ise_endpoint` resource and data source

--- a/docs/resources/endpoint.md
+++ b/docs/resources/endpoint.md
@@ -31,7 +31,6 @@ resource "ise_endpoint" "example" {
 
 ### Required
 
-- `group_id` (String) Identity Group ID
 - `mac` (String) MAC address of the endpoint
 - `name` (String) The name of the endpoint
 - `static_group_assignment` (Boolean) Static Group Assignment
@@ -41,6 +40,7 @@ resource "ise_endpoint" "example" {
 
 - `custom_attributes` (Map of String) Custom Attributes
 - `description` (String) Description
+- `group_id` (String) Identity Group ID
 - `identity_store` (String) Identity Store
 - `identity_store_id` (String) Identity Store Id
 - `mdm_compliance_status` (Boolean) Mdm Compliance Status

--- a/gen/definitions/endpoint.yaml
+++ b/gen/definitions/endpoint.yaml
@@ -23,7 +23,6 @@ attributes:
     example: 00:11:22:33:44:55
   - model_name: groupId
     data_path: [ERSEndPoint]
-    mandatory: true
     type: String
     description: Identity Group ID
     example: 3a88eec0-8c00-11e6-996c-525400b48521

--- a/internal/provider/resource_ise_endpoint.go
+++ b/internal/provider/resource_ise_endpoint.go
@@ -88,7 +88,7 @@ func (r *EndpointResource) Schema(ctx context.Context, req resource.SchemaReques
 			},
 			"group_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Identity Group ID").String,
-				Required:            true,
+				Optional:            true,
 			},
 			"profile_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Profile ID").String,

--- a/internal/provider/resource_ise_endpoint_test.go
+++ b/internal/provider/resource_ise_endpoint_test.go
@@ -82,7 +82,6 @@ func testAccIseEndpointConfig_minimum() string {
 	config := `resource "ise_endpoint" "test" {` + "\n"
 	config += `	name = "00:11:22:33:44:55"` + "\n"
 	config += `	mac = "00:11:22:33:44:55"` + "\n"
-	config += `	group_id = ise_endpoint_identity_group.test.id` + "\n"
 	config += `	static_profile_assignment = true` + "\n"
 	config += `	static_group_assignment = true` + "\n"
 	config += `}` + "\n"

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.2.1 (unreleased)
+
+- Make `groupId` attribute of `ise_endpoint` resource optional
+
 ## 0.2.0
 
 - Add `ise_endpoint` resource and data source


### PR DESCRIPTION
ERS API documentation claims that groupId is mandatory attribute but in reality its not. 
This is valid terraform resource definition which works:

```
resource "ise_endpoint" "Test" {
  description = "Test"
  mac = "FF:FF:FF:FF:FF:FF"
  name = "Test"
  static_group_assignment = "false"
  static_profile_assignment = "false"
}
```