### PR TITLE
fixing typo in word environment under device trustsec configuration

### DIFF
--- a/docs/data-sources/network_device.md
+++ b/docs/data-sources/network_device.md
@@ -56,7 +56,7 @@ data "ise_network_device" "example" {
 - `trustsec_coa_source_host` (String) CoA source host
 - `trustsec_device_id` (String) TrustSec device ID
 - `trustsec_device_password` (String) TrustSec device password
-- `trustsec_download_enviroment_data_every_x_seconds` (Number) Download environment data every X seconds
+- `trustsec_download_environment_data_every_x_seconds` (Number) Download environment data every X seconds
 - `trustsec_download_peer_authorization_policy_every_x_seconds` (Number) Download peer authorization policy every X seconds
 - `trustsec_download_sgacl_lists_every_x_seconds` (Number) Download SGACL lists every X seconds
 - `trustsec_enable_mode_password` (String) Enable mode password

--- a/docs/resources/network_device.md
+++ b/docs/resources/network_device.md
@@ -51,7 +51,7 @@ resource "ise_network_device" "example" {
   trustsec_exec_mode_password                                 = "cisco123"
   trustsec_exec_mode_username                                 = "user456"
   trustsec_include_when_deploying_sgt_updates                 = true
-  trustsec_download_enviroment_data_every_x_seconds           = 1000
+  trustsec_download_environment_data_every_x_seconds          = 1000
   trustsec_download_peer_authorization_policy_every_x_seconds = 1000
   trustsec_download_sgacl_lists_every_x_seconds               = 1000
   trustsec_other_sga_devices_to_trust_this_device             = true
@@ -105,7 +105,7 @@ resource "ise_network_device" "example" {
 - `trustsec_coa_source_host` (String) CoA source host
 - `trustsec_device_id` (String) TrustSec device ID
 - `trustsec_device_password` (String) TrustSec device password
-- `trustsec_download_enviroment_data_every_x_seconds` (Number) Download environment data every X seconds
+- `trustsec_download_environment_data_every_x_seconds` (Number) Download environment data every X seconds
 - `trustsec_download_peer_authorization_policy_every_x_seconds` (Number) Download peer authorization policy every X seconds
 - `trustsec_download_sgacl_lists_every_x_seconds` (Number) Download SGACL lists every X seconds
 - `trustsec_enable_mode_password` (String) Enable mode password

--- a/examples/resources/ise_network_device/resource.tf
+++ b/examples/resources/ise_network_device/resource.tf
@@ -36,7 +36,7 @@ resource "ise_network_device" "example" {
   trustsec_exec_mode_password                                 = "cisco123"
   trustsec_exec_mode_username                                 = "user456"
   trustsec_include_when_deploying_sgt_updates                 = true
-  trustsec_download_enviroment_data_every_x_seconds           = 1000
+  trustsec_download_environment_data_every_x_seconds          = 1000
   trustsec_download_peer_authorization_policy_every_x_seconds = 1000
   trustsec_download_sgacl_lists_every_x_seconds               = 1000
   trustsec_other_sga_devices_to_trust_this_device             = true

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -232,7 +232,7 @@ attributes:
     example: true
   - model_name: downlaodEnvironmentDataEveryXSeconds
     data_path: [NetworkDevice, trustsecsettings, sgaNotificationAndUpdates]
-    tf_name: trustsec_download_enviroment_data_every_x_seconds
+    tf_name: trustsec_download_environment_data_every_x_seconds
     type: Int64
     description: Download environment data every X seconds
     example: 1000

--- a/internal/provider/data_source_ise_network_device.go
+++ b/internal/provider/data_source_ise_network_device.go
@@ -225,7 +225,7 @@ func (d *NetworkDeviceDataSource) Schema(ctx context.Context, req datasource.Sch
 				MarkdownDescription: "Include this device when deploying Security Group Tag Mapping Updates",
 				Computed:            true,
 			},
-			"trustsec_download_enviroment_data_every_x_seconds": schema.Int64Attribute{
+			"trustsec_download_environment_data_every_x_seconds": schema.Int64Attribute{
 				MarkdownDescription: "Download environment data every X seconds",
 				Computed:            true,
 			},

--- a/internal/provider/data_source_ise_network_device_test.go
+++ b/internal/provider/data_source_ise_network_device_test.go
@@ -63,7 +63,7 @@ func TestAccDataSourceIseNetworkDevice(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_exec_mode_password", "cisco123"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_exec_mode_username", "user456"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_include_when_deploying_sgt_updates", "true"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_download_enviroment_data_every_x_seconds", "1000"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_download_environment_data_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_download_peer_authorization_policy_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_download_sgacl_lists_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.ise_network_device.test", "trustsec_other_sga_devices_to_trust_this_device", "true"))
@@ -125,7 +125,7 @@ func testAccDataSourceIseNetworkDeviceConfig() string {
 	config += `	trustsec_exec_mode_password = "cisco123"` + "\n"
 	config += `	trustsec_exec_mode_username = "user456"` + "\n"
 	config += `	trustsec_include_when_deploying_sgt_updates = true` + "\n"
-	config += `	trustsec_download_enviroment_data_every_x_seconds = 1000` + "\n"
+	config += `	trustsec_download_environment_data_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_download_peer_authorization_policy_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_download_sgacl_lists_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_other_sga_devices_to_trust_this_device = true` + "\n"

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -68,7 +68,7 @@ type NetworkDevice struct {
 	TrustsecExecModePassword                             types.String       `tfsdk:"trustsec_exec_mode_password"`
 	TrustsecExecModeUsername                             types.String       `tfsdk:"trustsec_exec_mode_username"`
 	TrustsecIncludeWhenDeployingSgtUpdates               types.Bool         `tfsdk:"trustsec_include_when_deploying_sgt_updates"`
-	TrustsecDownloadEnviromentDataEveryXSeconds          types.Int64        `tfsdk:"trustsec_download_enviroment_data_every_x_seconds"`
+	TrustsecDownloadEnvironmentDataEveryXSeconds          types.Int64        `tfsdk:"trustsec_download_environment_data_every_x_seconds"`
 	TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds types.Int64        `tfsdk:"trustsec_download_peer_authorization_policy_every_x_seconds"`
 	TrustsecDownloadSgaclListsEveryXSeconds              types.Int64        `tfsdk:"trustsec_download_sgacl_lists_every_x_seconds"`
 	TrustsecOtherSgaDevicesToTrustThisDevice             types.Bool         `tfsdk:"trustsec_other_sga_devices_to_trust_this_device"`
@@ -217,8 +217,8 @@ func (data NetworkDevice) toBody(ctx context.Context, state NetworkDevice) strin
 	if !data.TrustsecIncludeWhenDeployingSgtUpdates.IsNull() {
 		body, _ = sjson.Set(body, "NetworkDevice.trustsecsettings.deviceConfigurationDeployment.includeWhenDeployingSGTUpdates", data.TrustsecIncludeWhenDeployingSgtUpdates.ValueBool())
 	}
-	if !data.TrustsecDownloadEnviromentDataEveryXSeconds.IsNull() {
-		body, _ = sjson.Set(body, "NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodEnvironmentDataEveryXSeconds", data.TrustsecDownloadEnviromentDataEveryXSeconds.ValueInt64())
+	if !data.TrustsecDownloadEnvironmentDataEveryXSeconds.IsNull() {
+		body, _ = sjson.Set(body, "NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodEnvironmentDataEveryXSeconds", data.TrustsecDownloadEnvironmentDataEveryXSeconds.ValueInt64())
 	}
 	if !data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds.IsNull() {
 		body, _ = sjson.Set(body, "NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodPeerAuthorizationPolicyEveryXSeconds", data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds.ValueInt64())
@@ -432,9 +432,9 @@ func (data *NetworkDevice) fromBody(ctx context.Context, res gjson.Result) {
 		data.TrustsecIncludeWhenDeployingSgtUpdates = types.BoolNull()
 	}
 	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodEnvironmentDataEveryXSeconds"); value.Exists() && value.Type != gjson.Null {
-		data.TrustsecDownloadEnviromentDataEveryXSeconds = types.Int64Value(value.Int())
+		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Value(value.Int())
 	} else {
-		data.TrustsecDownloadEnviromentDataEveryXSeconds = types.Int64Null()
+		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Null()
 	}
 	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodPeerAuthorizationPolicyEveryXSeconds"); value.Exists() && value.Type != gjson.Null {
 		data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds = types.Int64Value(value.Int())
@@ -676,10 +676,10 @@ func (data *NetworkDevice) updateFromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.TrustsecIncludeWhenDeployingSgtUpdates = types.BoolNull()
 	}
-	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodEnvironmentDataEveryXSeconds"); value.Exists() && !data.TrustsecDownloadEnviromentDataEveryXSeconds.IsNull() {
-		data.TrustsecDownloadEnviromentDataEveryXSeconds = types.Int64Value(value.Int())
+	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downloadEnvironmentDataEveryXSeconds"); value.Exists() && !data.TrustsecDownloadEnvironmentDataEveryXSeconds.IsNull() {
+		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Value(value.Int())
 	} else {
-		data.TrustsecDownloadEnviromentDataEveryXSeconds = types.Int64Null()
+		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Null()
 	}
 	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodPeerAuthorizationPolicyEveryXSeconds"); value.Exists() && !data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds.IsNull() {
 		data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds = types.Int64Value(value.Int())
@@ -824,7 +824,7 @@ func (data *NetworkDevice) isNull(ctx context.Context, res gjson.Result) bool {
 	if !data.TrustsecIncludeWhenDeployingSgtUpdates.IsNull() {
 		return false
 	}
-	if !data.TrustsecDownloadEnviromentDataEveryXSeconds.IsNull() {
+	if !data.TrustsecDownloadEnvironmentDataEveryXSeconds.IsNull() {
 		return false
 	}
 	if !data.TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds.IsNull() {

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -68,7 +68,7 @@ type NetworkDevice struct {
 	TrustsecExecModePassword                             types.String       `tfsdk:"trustsec_exec_mode_password"`
 	TrustsecExecModeUsername                             types.String       `tfsdk:"trustsec_exec_mode_username"`
 	TrustsecIncludeWhenDeployingSgtUpdates               types.Bool         `tfsdk:"trustsec_include_when_deploying_sgt_updates"`
-	TrustsecDownloadEnvironmentDataEveryXSeconds          types.Int64        `tfsdk:"trustsec_download_environment_data_every_x_seconds"`
+	TrustsecDownloadEnvironmentDataEveryXSeconds         types.Int64        `tfsdk:"trustsec_download_environment_data_every_x_seconds"`
 	TrustsecDownloadPeerAuthorizationPolicyEveryXSeconds types.Int64        `tfsdk:"trustsec_download_peer_authorization_policy_every_x_seconds"`
 	TrustsecDownloadSgaclListsEveryXSeconds              types.Int64        `tfsdk:"trustsec_download_sgacl_lists_every_x_seconds"`
 	TrustsecOtherSgaDevicesToTrustThisDevice             types.Bool         `tfsdk:"trustsec_other_sga_devices_to_trust_this_device"`

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -676,7 +676,7 @@ func (data *NetworkDevice) updateFromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.TrustsecIncludeWhenDeployingSgtUpdates = types.BoolNull()
 	}
-	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downloadEnvironmentDataEveryXSeconds"); value.Exists() && !data.TrustsecDownloadEnvironmentDataEveryXSeconds.IsNull() {
+	if value := res.Get("NetworkDevice.trustsecsettings.sgaNotificationAndUpdates.downlaodEnvironmentDataEveryXSeconds"); value.Exists() && !data.TrustsecDownloadEnvironmentDataEveryXSeconds.IsNull() {
 		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Value(value.Int())
 	} else {
 		data.TrustsecDownloadEnvironmentDataEveryXSeconds = types.Int64Null()

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -250,7 +250,7 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 				MarkdownDescription: helpers.NewAttributeDescription("Include this device when deploying Security Group Tag Mapping Updates").String,
 				Optional:            true,
 			},
-			"trustsec_download_enviroment_data_every_x_seconds": schema.Int64Attribute{
+			"trustsec_download_environment_data_every_x_seconds": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Download environment data every X seconds").String,
 				Optional:            true,
 			},

--- a/internal/provider/resource_ise_network_device_test.go
+++ b/internal/provider/resource_ise_network_device_test.go
@@ -64,7 +64,7 @@ func TestAccIseNetworkDevice(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_exec_mode_password", "cisco123"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_exec_mode_username", "user456"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_include_when_deploying_sgt_updates", "true"))
-	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_download_enviroment_data_every_x_seconds", "1000"))
+	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_download_environment_data_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_download_peer_authorization_policy_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_download_sgacl_lists_every_x_seconds", "1000"))
 	checks = append(checks, resource.TestCheckResourceAttr("ise_network_device.test", "trustsec_other_sga_devices_to_trust_this_device", "true"))
@@ -150,7 +150,7 @@ func testAccIseNetworkDeviceConfig_all() string {
 	config += `	trustsec_exec_mode_password = "cisco123"` + "\n"
 	config += `	trustsec_exec_mode_username = "user456"` + "\n"
 	config += `	trustsec_include_when_deploying_sgt_updates = true` + "\n"
-	config += `	trustsec_download_enviroment_data_every_x_seconds = 1000` + "\n"
+	config += `	trustsec_download_environment_data_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_download_peer_authorization_policy_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_download_sgacl_lists_every_x_seconds = 1000` + "\n"
 	config += `	trustsec_other_sga_devices_to_trust_this_device = true` + "\n"


### PR DESCRIPTION
# Issue description
Provider code includes word environment without the first "n" in TrustSec network device related objects.
Example:
```yaml
  trustsec_device_id                                          = "device123"
  trustsec_device_password                                    = "cisco123"
  trustsec_rest_api_username                                  = "user123"
  trustsec_rest_api_password                                  = "Cisco123"
  trustsec_enable_mode_password                               = "cisco123"
  trustsec_exec_mode_password                                 = "cisco123"
  trustsec_exec_mode_username                                 = "user456"
  trustsec_include_when_deploying_sgt_updates                 = true
  trustsec_download_enviroment_data_every_x_seconds          = 1000
  trustsec_download_peer_authorization_policy_every_x_seconds = 1000
  trustsec_download_sgacl_lists_every_x_seconds               = 1000
  trustsec_other_sga_devices_to_trust_this_device             = true
  trustsec_re_authentication_every_x_seconds                  = 1000
  trustsec_send_configuration_to_device                       = true
  trustsec_send_configuration_to_device_using                 = "ENABLE_USING_COA"
```

Cisco ISE API does include the "n" correctly.
Example:
```bash
        "trustsecsettings": {
            "deviceAuthenticationSettings": {
                "sgaDeviceId": "test",
                "sgaDevicePassword": "test"
            },
            "sgaNotificationAndUpdates": {
                "downlaodEnvironmentDataEveryXSeconds": 86400,
                "downlaodPeerAuthorizationPolicyEveryXSeconds": 86400,
                "reAuthenticationEveryXSeconds": 86400,
                "downloadSGACLListsEveryXSeconds": 86400,
                "otherSGADevicesToTrustThisDevice": true,
                "sendConfigurationToDevice": false,
                "sendConfigurationToDeviceUsing": "DISABLE_ALL"
            },
            "deviceConfigurationDeployment": {
                "includeWhenDeployingSGTUpdates": false,
                "enableModePassword": "",
                "execModePassword": ""
            },
            "pushIdSupport": "false"
        },
```