### PR TITLE
Fix updating network_devices with existing TrustSec config - issue #60

### DIFF
--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -2,6 +2,7 @@
 name: Network Device
 rest_endpoint: /ers/config/networkdevice
 data_source_name_query: true
+put_id_include_path: NetworkDevice
 doc_category: Network Resources
 attributes:
   - model_name: name

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -100,7 +100,7 @@ func (data NetworkDevice) getPath() string {
 //template:begin toBody
 func (data NetworkDevice) toBody(ctx context.Context, state NetworkDevice) string {
 	body := ""
-	if !data.Id.IsNull() {
+	if data.Id.ValueString() != "" {
 		body, _ = sjson.Set(body, "NetworkDevice.id", data.Id.ValueString())
 	}
 	if !data.Name.IsNull() {

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -100,6 +100,9 @@ func (data NetworkDevice) getPath() string {
 //template:begin toBody
 func (data NetworkDevice) toBody(ctx context.Context, state NetworkDevice) string {
 	body := ""
+	if !data.Id.IsNull() {
+		body, _ = sjson.Set(body, "NetworkDevice.id", data.Id.ValueString())
+	}
 	if !data.Name.IsNull() {
 		body, _ = sjson.Set(body, "NetworkDevice.name", data.Name.ValueString())
 	}


### PR DESCRIPTION
Updating existing network devices with TrustSec configured resulted in below error because of missing "id" attribute in the PUT request body:

```
│ Failed to configure object (PUT), got error: HTTP Request failed: StatusCode 400, Message: Validation Error - Illegal values: [trustsecsettings: sgaNotificationAndUpdates: SGA Device ID should be unique], {
│   "ERSResponse" : {
│     "operation" : "PUT-update-networkdevice",
│     "messages" : [ {
│       "title" : "Validation Error - Illegal values: [trustsecsettings: sgaNotificationAndUpdates: SGA Device ID should be unique]",
│       "type" : "ERROR",
│       "code" : "Application resource validation exception"
│     } ],
│     "link" : {
│       "rel" : "related",
│       "href" : "https://10.123.0.22/ers/config/networkdevice/64670970-1595-11f0-a1a7-0050569237e7",
│       "type" : "application/xml"
│     }
│   }
│ }
```

Fixes: https://github.com/CiscoDevNet/terraform-provider-ise/issues/60