### PR TITLE
Extend condition children nesting from 4 to 6 levels

### DIFF
--- a/docs/data-sources/device_admin_condition.md
+++ b/docs/data-sources/device_admin_condition.md
@@ -94,9 +94,28 @@ Read-Only:
 
 - `attribute_name` (String) Dictionary attribute name
 - `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children))
 - `condition_type` (String) Condition type.
 - `dictionary_name` (String) Dictionary name
 - `dictionary_value` (String) Dictionary value
 - `id` (String) UUID for condition
 - `is_negate` (Boolean) Indicates whereas this condition is in negate mode
 - `operator` (String) Equality operator
+
+<a id="nestedatt--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children`
+
+Read-Only:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children--children))
+- `condition_type` (String) Condition type.
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+
+<a id="nestedatt--children--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children.children`

--- a/docs/data-sources/network_access_condition.md
+++ b/docs/data-sources/network_access_condition.md
@@ -94,9 +94,28 @@ Read-Only:
 
 - `attribute_name` (String) Dictionary attribute name
 - `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children))
 - `condition_type` (String) Condition type.
 - `dictionary_name` (String) Dictionary name
 - `dictionary_value` (String) Dictionary value
 - `id` (String) UUID for condition
 - `is_negate` (Boolean) Indicates whereas this condition is in negate mode
 - `operator` (String) Equality operator
+
+<a id="nestedatt--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children`
+
+Read-Only:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children--children))
+- `condition_type` (String) Condition type.
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+
+<a id="nestedatt--children--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children.children`

--- a/docs/resources/device_admin_condition.md
+++ b/docs/resources/device_admin_condition.md
@@ -120,6 +120,46 @@ Optional:
 Required:
 
 - `condition_type` (String) Condition type.
+  - Choices: `ConditionAndBlock`, `ConditionAttributes`, `ConditionOrBlock`, `ConditionReference`
+
+Optional:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children))
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+  - Choices: `contains`, `endsWith`, `equals`, `greaterOrEquals`, `greaterThan`, `in`, `ipEquals`, `ipGreaterThan`, `ipLessThan`, `ipNotEquals`, `lessOrEquals`, `lessThan`, `matches`, `notContains`, `notEndsWith`, `notEquals`, `notIn`, `notStartsWith`, `startsWith`
+
+<a id="nestedatt--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children`
+
+Required:
+
+- `condition_type` (String) Condition type.
+  - Choices: `ConditionAndBlock`, `ConditionAttributes`, `ConditionOrBlock`, `ConditionReference`
+
+Optional:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children--children))
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+  - Choices: `contains`, `endsWith`, `equals`, `greaterOrEquals`, `greaterThan`, `in`, `ipEquals`, `ipGreaterThan`, `ipLessThan`, `ipNotEquals`, `lessOrEquals`, `lessThan`, `matches`, `notContains`, `notEndsWith`, `notEquals`, `notIn`, `notStartsWith`, `startsWith`
+
+<a id="nestedatt--children--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children.children`
+
+Required:
+
+- `condition_type` (String) Condition type.
   - Choices: `ConditionAttributes`, `ConditionReference`
 
 Optional:

--- a/docs/resources/network_access_condition.md
+++ b/docs/resources/network_access_condition.md
@@ -120,6 +120,46 @@ Optional:
 Required:
 
 - `condition_type` (String) Condition type.
+  - Choices: `ConditionAndBlock`, `ConditionAttributes`, `ConditionOrBlock`, `ConditionReference`
+
+Optional:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children))
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+  - Choices: `contains`, `endsWith`, `equals`, `greaterOrEquals`, `greaterThan`, `in`, `ipEquals`, `ipGreaterThan`, `ipLessThan`, `ipNotEquals`, `lessOrEquals`, `lessThan`, `matches`, `notContains`, `notEndsWith`, `notEquals`, `notIn`, `notStartsWith`, `startsWith`
+
+<a id="nestedatt--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children`
+
+Required:
+
+- `condition_type` (String) Condition type.
+  - Choices: `ConditionAndBlock`, `ConditionAttributes`, `ConditionOrBlock`, `ConditionReference`
+
+Optional:
+
+- `attribute_name` (String) Dictionary attribute name
+- `attribute_value` (String) Attribute value for condition
+- `children` (Attributes List) List of child conditions (see [below for nested schema](#nestedatt--children--children--children--children--children--children))
+- `dictionary_name` (String) Dictionary name
+- `dictionary_value` (String) Dictionary value
+- `id` (String) UUID for condition
+- `is_negate` (Boolean) Indicates whereas this condition is in negate mode
+- `operator` (String) Equality operator
+  - Choices: `contains`, `endsWith`, `equals`, `greaterOrEquals`, `greaterThan`, `in`, `ipEquals`, `ipGreaterThan`, `ipLessThan`, `ipNotEquals`, `lessOrEquals`, `lessThan`, `matches`, `notContains`, `notEndsWith`, `notEquals`, `notIn`, `notStartsWith`, `startsWith`
+
+<a id="nestedatt--children--children--children--children--children--children"></a>
+### Nested Schema for `children.children.children.children.children.children`
+
+Required:
+
+- `condition_type` (String) Condition type.
   - Choices: `ConditionAttributes`, `ConditionReference`
 
 Optional:

--- a/gen/definitions/device_admin_condition.yaml
+++ b/gen/definitions/device_admin_condition.yaml
@@ -325,7 +325,13 @@ attributes:
                   - model_name: conditionType
                     mandatory: true
                     type: String
-                    enum_values: [ConditionAttributes, ConditionReference]
+                    enum_values:
+                      [
+                        ConditionAndBlock,
+                        ConditionAttributes,
+                        ConditionOrBlock,
+                        ConditionReference,
+                      ]
                     description: Condition type.
                   - model_name: id
                     type: String
@@ -370,3 +376,113 @@ attributes:
                         startsWith,
                       ]
                     description: Equality operator
+                  - model_name: children
+                    type: List
+                    description: List of child conditions
+                    attributes:
+                      - model_name: conditionType
+                        mandatory: true
+                        type: String
+                        enum_values:
+                          [
+                            ConditionAndBlock,
+                            ConditionAttributes,
+                            ConditionOrBlock,
+                            ConditionReference,
+                          ]
+                        description: Condition type.
+                      - model_name: id
+                        type: String
+                        description: UUID for condition
+                      - model_name: isNegate
+                        type: Bool
+                        description: Indicates whereas this condition is in negate mode
+                      - model_name: attributeName
+                        type: String
+                        description: Dictionary attribute name
+                      - model_name: attributeValue
+                        type: String
+                        description: Attribute value for condition
+                      - model_name: dictionaryName
+                        type: String
+                        description: Dictionary name
+                      - model_name: dictionaryValue
+                        type: String
+                        description: Dictionary value
+                      - model_name: operator
+                        type: String
+                        enum_values:
+                          [
+                            contains,
+                            endsWith,
+                            equals,
+                            greaterOrEquals,
+                            greaterThan,
+                            in,
+                            ipEquals,
+                            ipGreaterThan,
+                            ipLessThan,
+                            ipNotEquals,
+                            lessOrEquals,
+                            lessThan,
+                            matches,
+                            notContains,
+                            notEndsWith,
+                            notEquals,
+                            notIn,
+                            notStartsWith,
+                            startsWith,
+                          ]
+                        description: Equality operator
+                      - model_name: children
+                        type: List
+                        description: List of child conditions
+                        attributes:
+                          - model_name: conditionType
+                            mandatory: true
+                            type: String
+                            enum_values: [ConditionAttributes, ConditionReference]
+                            description: Condition type.
+                          - model_name: id
+                            type: String
+                            description: UUID for condition
+                          - model_name: isNegate
+                            type: Bool
+                            description: Indicates whereas this condition is in negate mode
+                          - model_name: attributeName
+                            type: String
+                            description: Dictionary attribute name
+                          - model_name: attributeValue
+                            type: String
+                            description: Attribute value for condition
+                          - model_name: dictionaryName
+                            type: String
+                            description: Dictionary name
+                          - model_name: dictionaryValue
+                            type: String
+                            description: Dictionary value
+                          - model_name: operator
+                            type: String
+                            enum_values:
+                              [
+                                contains,
+                                endsWith,
+                                equals,
+                                greaterOrEquals,
+                                greaterThan,
+                                in,
+                                ipEquals,
+                                ipGreaterThan,
+                                ipLessThan,
+                                ipNotEquals,
+                                lessOrEquals,
+                                lessThan,
+                                matches,
+                                notContains,
+                                notEndsWith,
+                                notEquals,
+                                notIn,
+                                notStartsWith,
+                                startsWith,
+                              ]
+                            description: Equality operator

--- a/gen/definitions/network_access_condition.yaml
+++ b/gen/definitions/network_access_condition.yaml
@@ -339,7 +339,13 @@ attributes:
                   - model_name: conditionType
                     mandatory: true
                     type: String
-                    enum_values: [ConditionAttributes, ConditionReference]
+                    enum_values:
+                      [
+                        ConditionAndBlock,
+                        ConditionAttributes,
+                        ConditionOrBlock,
+                        ConditionReference,
+                      ]
                     description: Condition type.
                     example: ConditionAttributes
                   - model_name: id
@@ -385,3 +391,115 @@ attributes:
                         startsWith,
                       ]
                     description: Equality operator
+                  - model_name: children
+                    type: List
+                    description: List of child conditions
+                    attributes:
+                      - model_name: conditionType
+                        mandatory: true
+                        type: String
+                        enum_values:
+                          [
+                            ConditionAndBlock,
+                            ConditionAttributes,
+                            ConditionOrBlock,
+                            ConditionReference,
+                          ]
+                        description: Condition type.
+                        example: ConditionAttributes
+                      - model_name: id
+                        type: String
+                        description: UUID for condition
+                      - model_name: isNegate
+                        type: Bool
+                        description: Indicates whereas this condition is in negate mode
+                      - model_name: attributeName
+                        type: String
+                        description: Dictionary attribute name
+                      - model_name: attributeValue
+                        type: String
+                        description: Attribute value for condition
+                      - model_name: dictionaryName
+                        type: String
+                        description: Dictionary name
+                      - model_name: dictionaryValue
+                        type: String
+                        description: Dictionary value
+                      - model_name: operator
+                        type: String
+                        enum_values:
+                          [
+                            contains,
+                            endsWith,
+                            equals,
+                            greaterOrEquals,
+                            greaterThan,
+                            in,
+                            ipEquals,
+                            ipGreaterThan,
+                            ipLessThan,
+                            ipNotEquals,
+                            lessOrEquals,
+                            lessThan,
+                            matches,
+                            notContains,
+                            notEndsWith,
+                            notEquals,
+                            notIn,
+                            notStartsWith,
+                            startsWith,
+                          ]
+                        description: Equality operator
+                      - model_name: children
+                        type: List
+                        description: List of child conditions
+                        attributes:
+                          - model_name: conditionType
+                            mandatory: true
+                            type: String
+                            enum_values: [ConditionAttributes, ConditionReference]
+                            description: Condition type.
+                            example: ConditionAttributes
+                          - model_name: id
+                            type: String
+                            description: UUID for condition
+                          - model_name: isNegate
+                            type: Bool
+                            description: Indicates whereas this condition is in negate mode
+                          - model_name: attributeName
+                            type: String
+                            description: Dictionary attribute name
+                          - model_name: attributeValue
+                            type: String
+                            description: Attribute value for condition
+                          - model_name: dictionaryName
+                            type: String
+                            description: Dictionary name
+                          - model_name: dictionaryValue
+                            type: String
+                            description: Dictionary value
+                          - model_name: operator
+                            type: String
+                            enum_values:
+                              [
+                                contains,
+                                endsWith,
+                                equals,
+                                greaterOrEquals,
+                                greaterThan,
+                                in,
+                                ipEquals,
+                                ipGreaterThan,
+                                ipLessThan,
+                                ipNotEquals,
+                                lessOrEquals,
+                                lessThan,
+                                matches,
+                                notContains,
+                                notEndsWith,
+                                notEquals,
+                                notIn,
+                                notStartsWith,
+                                startsWith,
+                              ]
+                            description: Equality operator

--- a/internal/provider/data_source_ise_device_admin_condition.go
+++ b/internal/provider/data_source_ise_device_admin_condition.go
@@ -272,6 +272,50 @@ func (d *DeviceAdminConditionDataSource) Schema(ctx context.Context, req datasou
 																MarkdownDescription: "Equality operator",
 																Computed:            true,
 															},
+															"children": schema.ListNestedAttribute{
+																MarkdownDescription: "List of child conditions",
+																Computed:            true,
+																NestedObject: schema.NestedAttributeObject{
+																	Attributes: map[string]schema.Attribute{
+																		"condition_type": schema.StringAttribute{
+																			MarkdownDescription: "Condition type.",
+																			Computed:            true,
+																		},
+																		"id": schema.StringAttribute{
+																			MarkdownDescription: "UUID for condition",
+																			Computed:            true,
+																		},
+																		"is_negate": schema.BoolAttribute{
+																			MarkdownDescription: "Indicates whereas this condition is in negate mode",
+																			Computed:            true,
+																		},
+																		"attribute_name": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary attribute name",
+																			Computed:            true,
+																		},
+																		"attribute_value": schema.StringAttribute{
+																			MarkdownDescription: "Attribute value for condition",
+																			Computed:            true,
+																		},
+																		"dictionary_name": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary name",
+																			Computed:            true,
+																		},
+																		"dictionary_value": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary value",
+																			Computed:            true,
+																		},
+																		"operator": schema.StringAttribute{
+																			MarkdownDescription: "Equality operator",
+																			Computed:            true,
+																		},
+																		"children": schema.ListNestedAttribute{
+																			MarkdownDescription: "List of child conditions",
+																			Computed:            true,
+																		},
+																	},
+																},
+															},
 														},
 													},
 												},

--- a/internal/provider/data_source_ise_network_access_condition.go
+++ b/internal/provider/data_source_ise_network_access_condition.go
@@ -272,6 +272,50 @@ func (d *NetworkAccessConditionDataSource) Schema(ctx context.Context, req datas
 																MarkdownDescription: "Equality operator",
 																Computed:            true,
 															},
+															"children": schema.ListNestedAttribute{
+																MarkdownDescription: "List of child conditions",
+																Computed:            true,
+																NestedObject: schema.NestedAttributeObject{
+																	Attributes: map[string]schema.Attribute{
+																		"condition_type": schema.StringAttribute{
+																			MarkdownDescription: "Condition type.",
+																			Computed:            true,
+																		},
+																		"id": schema.StringAttribute{
+																			MarkdownDescription: "UUID for condition",
+																			Computed:            true,
+																		},
+																		"is_negate": schema.BoolAttribute{
+																			MarkdownDescription: "Indicates whereas this condition is in negate mode",
+																			Computed:            true,
+																		},
+																		"attribute_name": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary attribute name",
+																			Computed:            true,
+																		},
+																		"attribute_value": schema.StringAttribute{
+																			MarkdownDescription: "Attribute value for condition",
+																			Computed:            true,
+																		},
+																		"dictionary_name": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary name",
+																			Computed:            true,
+																		},
+																		"dictionary_value": schema.StringAttribute{
+																			MarkdownDescription: "Dictionary value",
+																			Computed:            true,
+																		},
+																		"operator": schema.StringAttribute{
+																			MarkdownDescription: "Equality operator",
+																			Computed:            true,
+																		},
+																		"children": schema.ListNestedAttribute{
+																			MarkdownDescription: "List of child conditions",
+																			Computed:            true,
+																		},
+																	},
+																},
+															},
 														},
 													},
 												},

--- a/internal/provider/model_ise_device_admin_condition.go
+++ b/internal/provider/model_ise_device_admin_condition.go
@@ -87,6 +87,30 @@ type DeviceAdminConditionChildrenChildrenChildren struct {
 }
 
 type DeviceAdminConditionChildrenChildrenChildrenChildren struct {
+	ConditionType   types.String                                                   `tfsdk:"condition_type"`
+	Id              types.String                                                   `tfsdk:"id"`
+	IsNegate        types.Bool                                                     `tfsdk:"is_negate"`
+	AttributeName   types.String                                                   `tfsdk:"attribute_name"`
+	AttributeValue  types.String                                                   `tfsdk:"attribute_value"`
+	DictionaryName  types.String                                                   `tfsdk:"dictionary_name"`
+	DictionaryValue types.String                                                   `tfsdk:"dictionary_value"`
+	Operator        types.String                                                   `tfsdk:"operator"`
+	Children        []DeviceAdminConditionChildrenChildrenChildrenChildrenChildren `tfsdk:"children"`
+}
+
+type DeviceAdminConditionChildrenChildrenChildrenChildrenChildren struct {
+	ConditionType   types.String                                                           `tfsdk:"condition_type"`
+	Id              types.String                                                           `tfsdk:"id"`
+	IsNegate        types.Bool                                                             `tfsdk:"is_negate"`
+	AttributeName   types.String                                                           `tfsdk:"attribute_name"`
+	AttributeValue  types.String                                                           `tfsdk:"attribute_value"`
+	DictionaryName  types.String                                                           `tfsdk:"dictionary_name"`
+	DictionaryValue types.String                                                           `tfsdk:"dictionary_value"`
+	Operator        types.String                                                           `tfsdk:"operator"`
+	Children        []DeviceAdminConditionChildrenChildrenChildrenChildrenChildrenChildren `tfsdk:"children"`
+}
+
+type DeviceAdminConditionChildrenChildrenChildrenChildrenChildrenChildren struct {
 	ConditionType   types.String `tfsdk:"condition_type"`
 	Id              types.String `tfsdk:"id"`
 	IsNegate        types.Bool   `tfsdk:"is_negate"`
@@ -263,6 +287,68 @@ func (data DeviceAdminCondition) toBody(ctx context.Context, state DeviceAdminCo
 									}
 									if !childChildChildItem.Operator.IsNull() {
 										itemChildChildChildBody, _ = sjson.Set(itemChildChildChildBody, "operator", childChildChildItem.Operator.ValueString())
+									}
+									if len(childChildChildItem.Children) > 0 {
+										itemChildChildChildBody, _ = sjson.Set(itemChildChildChildBody, "children", []interface{}{})
+										for _, childChildChildChildItem := range childChildChildItem.Children {
+											itemChildChildChildChildBody := ""
+											if !childChildChildChildItem.ConditionType.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "conditionType", childChildChildChildItem.ConditionType.ValueString())
+											}
+											if !childChildChildChildItem.Id.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "id", childChildChildChildItem.Id.ValueString())
+											}
+											if !childChildChildChildItem.IsNegate.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "isNegate", childChildChildChildItem.IsNegate.ValueBool())
+											}
+											if !childChildChildChildItem.AttributeName.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "attributeName", childChildChildChildItem.AttributeName.ValueString())
+											}
+											if !childChildChildChildItem.AttributeValue.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "attributeValue", childChildChildChildItem.AttributeValue.ValueString())
+											}
+											if !childChildChildChildItem.DictionaryName.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "dictionaryName", childChildChildChildItem.DictionaryName.ValueString())
+											}
+											if !childChildChildChildItem.DictionaryValue.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "dictionaryValue", childChildChildChildItem.DictionaryValue.ValueString())
+											}
+											if !childChildChildChildItem.Operator.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "operator", childChildChildChildItem.Operator.ValueString())
+											}
+											if len(childChildChildChildItem.Children) > 0 {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "children", []interface{}{})
+												for _, childChildChildChildChildItem := range childChildChildChildItem.Children {
+													itemChildChildChildChildChildBody := ""
+													if !childChildChildChildChildItem.ConditionType.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "conditionType", childChildChildChildChildItem.ConditionType.ValueString())
+													}
+													if !childChildChildChildChildItem.Id.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "id", childChildChildChildChildItem.Id.ValueString())
+													}
+													if !childChildChildChildChildItem.IsNegate.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "isNegate", childChildChildChildChildItem.IsNegate.ValueBool())
+													}
+													if !childChildChildChildChildItem.AttributeName.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "attributeName", childChildChildChildChildItem.AttributeName.ValueString())
+													}
+													if !childChildChildChildChildItem.AttributeValue.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "attributeValue", childChildChildChildChildItem.AttributeValue.ValueString())
+													}
+													if !childChildChildChildChildItem.DictionaryName.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "dictionaryName", childChildChildChildChildItem.DictionaryName.ValueString())
+													}
+													if !childChildChildChildChildItem.DictionaryValue.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "dictionaryValue", childChildChildChildChildItem.DictionaryValue.ValueString())
+													}
+													if !childChildChildChildChildItem.Operator.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "operator", childChildChildChildChildItem.Operator.ValueString())
+													}
+													itemChildChildChildChildBody, _ = sjson.SetRaw(itemChildChildChildChildBody, "children.-1", itemChildChildChildChildChildBody)
+												}
+											}
+											itemChildChildChildBody, _ = sjson.SetRaw(itemChildChildChildBody, "children.-1", itemChildChildChildChildBody)
+										}
 									}
 									itemChildChildBody, _ = sjson.SetRaw(itemChildChildBody, "children.-1", itemChildChildChildBody)
 								}
@@ -814,6 +900,134 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringValue(value.String())
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
+					}
+					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
+						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
+						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
+
+						var ccccr gjson.Result
+						cccr.Get("children").ForEach(
+							func(_, v gjson.Result) bool {
+								found := false
+								for ik := range keys {
+									if v.Get(keys[ik]).String() == keyValues[ik] {
+										found = true
+										continue
+									}
+									found = false
+									break
+								}
+								if found {
+									ccccr = v
+									return false
+								}
+								return true
+							},
+						)
+						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringNull()
+						}
+						if value := ccccr.Get("id"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id = types.StringNull()
+						}
+						if value := ccccr.Get("isNegate"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate = types.BoolValue(value.Bool())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate = types.BoolNull()
+						}
+						if value := ccccr.Get("attributeName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName = types.StringNull()
+						}
+						if value := ccccr.Get("attributeValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue = types.StringNull()
+						}
+						if value := ccccr.Get("dictionaryName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName = types.StringNull()
+						}
+						if value := ccccr.Get("dictionaryValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue = types.StringNull()
+						}
+						if value := ccccr.Get("operator"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
+						}
+						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
+							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
+							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
+
+							var cccccr gjson.Result
+							ccccr.Get("children").ForEach(
+								func(_, v gjson.Result) bool {
+									found := false
+									for ik := range keys {
+										if v.Get(keys[ik]).String() == keyValues[ik] {
+											found = true
+											continue
+										}
+										found = false
+										break
+									}
+									if found {
+										cccccr = v
+										return false
+									}
+									return true
+								},
+							)
+							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringNull()
+							}
+							if value := cccccr.Get("id"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id = types.StringNull()
+							}
+							if value := cccccr.Get("isNegate"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate = types.BoolValue(value.Bool())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate = types.BoolNull()
+							}
+							if value := cccccr.Get("attributeName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName = types.StringNull()
+							}
+							if value := cccccr.Get("attributeValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue = types.StringNull()
+							}
+							if value := cccccr.Get("dictionaryName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName = types.StringNull()
+							}
+							if value := cccccr.Get("dictionaryValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue = types.StringNull()
+							}
+							if value := cccccr.Get("operator"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator = types.StringNull()
+							}
+						}
 					}
 				}
 			}

--- a/internal/provider/model_ise_network_access_condition.go
+++ b/internal/provider/model_ise_network_access_condition.go
@@ -87,6 +87,30 @@ type NetworkAccessConditionChildrenChildrenChildren struct {
 }
 
 type NetworkAccessConditionChildrenChildrenChildrenChildren struct {
+	ConditionType   types.String                                                     `tfsdk:"condition_type"`
+	Id              types.String                                                     `tfsdk:"id"`
+	IsNegate        types.Bool                                                       `tfsdk:"is_negate"`
+	AttributeName   types.String                                                     `tfsdk:"attribute_name"`
+	AttributeValue  types.String                                                     `tfsdk:"attribute_value"`
+	DictionaryName  types.String                                                     `tfsdk:"dictionary_name"`
+	DictionaryValue types.String                                                     `tfsdk:"dictionary_value"`
+	Operator        types.String                                                     `tfsdk:"operator"`
+	Children        []NetworkAccessConditionChildrenChildrenChildrenChildrenChildren `tfsdk:"children"`
+}
+
+type NetworkAccessConditionChildrenChildrenChildrenChildrenChildren struct {
+	ConditionType   types.String                                                             `tfsdk:"condition_type"`
+	Id              types.String                                                             `tfsdk:"id"`
+	IsNegate        types.Bool                                                               `tfsdk:"is_negate"`
+	AttributeName   types.String                                                             `tfsdk:"attribute_name"`
+	AttributeValue  types.String                                                             `tfsdk:"attribute_value"`
+	DictionaryName  types.String                                                             `tfsdk:"dictionary_name"`
+	DictionaryValue types.String                                                             `tfsdk:"dictionary_value"`
+	Operator        types.String                                                             `tfsdk:"operator"`
+	Children        []NetworkAccessConditionChildrenChildrenChildrenChildrenChildrenChildren `tfsdk:"children"`
+}
+
+type NetworkAccessConditionChildrenChildrenChildrenChildrenChildrenChildren struct {
 	ConditionType   types.String `tfsdk:"condition_type"`
 	Id              types.String `tfsdk:"id"`
 	IsNegate        types.Bool   `tfsdk:"is_negate"`
@@ -263,6 +287,68 @@ func (data NetworkAccessCondition) toBody(ctx context.Context, state NetworkAcce
 									}
 									if !childChildChildItem.Operator.IsNull() {
 										itemChildChildChildBody, _ = sjson.Set(itemChildChildChildBody, "operator", childChildChildItem.Operator.ValueString())
+									}
+									if len(childChildChildItem.Children) > 0 {
+										itemChildChildChildBody, _ = sjson.Set(itemChildChildChildBody, "children", []interface{}{})
+										for _, childChildChildChildItem := range childChildChildItem.Children {
+											itemChildChildChildChildBody := ""
+											if !childChildChildChildItem.ConditionType.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "conditionType", childChildChildChildItem.ConditionType.ValueString())
+											}
+											if !childChildChildChildItem.Id.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "id", childChildChildChildItem.Id.ValueString())
+											}
+											if !childChildChildChildItem.IsNegate.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "isNegate", childChildChildChildItem.IsNegate.ValueBool())
+											}
+											if !childChildChildChildItem.AttributeName.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "attributeName", childChildChildChildItem.AttributeName.ValueString())
+											}
+											if !childChildChildChildItem.AttributeValue.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "attributeValue", childChildChildChildItem.AttributeValue.ValueString())
+											}
+											if !childChildChildChildItem.DictionaryName.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "dictionaryName", childChildChildChildItem.DictionaryName.ValueString())
+											}
+											if !childChildChildChildItem.DictionaryValue.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "dictionaryValue", childChildChildChildItem.DictionaryValue.ValueString())
+											}
+											if !childChildChildChildItem.Operator.IsNull() {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "operator", childChildChildChildItem.Operator.ValueString())
+											}
+											if len(childChildChildChildItem.Children) > 0 {
+												itemChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildBody, "children", []interface{}{})
+												for _, childChildChildChildChildItem := range childChildChildChildItem.Children {
+													itemChildChildChildChildChildBody := ""
+													if !childChildChildChildChildItem.ConditionType.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "conditionType", childChildChildChildChildItem.ConditionType.ValueString())
+													}
+													if !childChildChildChildChildItem.Id.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "id", childChildChildChildChildItem.Id.ValueString())
+													}
+													if !childChildChildChildChildItem.IsNegate.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "isNegate", childChildChildChildChildItem.IsNegate.ValueBool())
+													}
+													if !childChildChildChildChildItem.AttributeName.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "attributeName", childChildChildChildChildItem.AttributeName.ValueString())
+													}
+													if !childChildChildChildChildItem.AttributeValue.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "attributeValue", childChildChildChildChildItem.AttributeValue.ValueString())
+													}
+													if !childChildChildChildChildItem.DictionaryName.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "dictionaryName", childChildChildChildChildItem.DictionaryName.ValueString())
+													}
+													if !childChildChildChildChildItem.DictionaryValue.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "dictionaryValue", childChildChildChildChildItem.DictionaryValue.ValueString())
+													}
+													if !childChildChildChildChildItem.Operator.IsNull() {
+														itemChildChildChildChildChildBody, _ = sjson.Set(itemChildChildChildChildChildBody, "operator", childChildChildChildChildItem.Operator.ValueString())
+													}
+													itemChildChildChildChildBody, _ = sjson.SetRaw(itemChildChildChildChildBody, "children.-1", itemChildChildChildChildChildBody)
+												}
+											}
+											itemChildChildChildBody, _ = sjson.SetRaw(itemChildChildChildBody, "children.-1", itemChildChildChildChildBody)
+										}
 									}
 									itemChildChildBody, _ = sjson.SetRaw(itemChildChildBody, "children.-1", itemChildChildChildBody)
 								}
@@ -814,6 +900,134 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringValue(value.String())
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
+					}
+					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
+						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
+						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
+
+						var ccccr gjson.Result
+						cccr.Get("children").ForEach(
+							func(_, v gjson.Result) bool {
+								found := false
+								for ik := range keys {
+									if v.Get(keys[ik]).String() == keyValues[ik] {
+										found = true
+										continue
+									}
+									found = false
+									break
+								}
+								if found {
+									ccccr = v
+									return false
+								}
+								return true
+							},
+						)
+						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringNull()
+						}
+						if value := ccccr.Get("id"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id = types.StringNull()
+						}
+						if value := ccccr.Get("isNegate"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate = types.BoolValue(value.Bool())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate = types.BoolNull()
+						}
+						if value := ccccr.Get("attributeName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName = types.StringNull()
+						}
+						if value := ccccr.Get("attributeValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue = types.StringNull()
+						}
+						if value := ccccr.Get("dictionaryName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName = types.StringNull()
+						}
+						if value := ccccr.Get("dictionaryValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue = types.StringNull()
+						}
+						if value := ccccr.Get("operator"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.IsNull() {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringValue(value.String())
+						} else {
+							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
+						}
+						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
+							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
+							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
+
+							var cccccr gjson.Result
+							ccccr.Get("children").ForEach(
+								func(_, v gjson.Result) bool {
+									found := false
+									for ik := range keys {
+										if v.Get(keys[ik]).String() == keyValues[ik] {
+											found = true
+											continue
+										}
+										found = false
+										break
+									}
+									if found {
+										cccccr = v
+										return false
+									}
+									return true
+								},
+							)
+							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringNull()
+							}
+							if value := cccccr.Get("id"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id = types.StringNull()
+							}
+							if value := cccccr.Get("isNegate"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate = types.BoolValue(value.Bool())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate = types.BoolNull()
+							}
+							if value := cccccr.Get("attributeName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName = types.StringNull()
+							}
+							if value := cccccr.Get("attributeValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue = types.StringNull()
+							}
+							if value := cccccr.Get("dictionaryName"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName = types.StringNull()
+							}
+							if value := cccccr.Get("dictionaryValue"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue = types.StringNull()
+							}
+							if value := cccccr.Get("operator"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.IsNull() {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator = types.StringValue(value.String())
+							} else {
+								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator = types.StringNull()
+							}
+						}
 					}
 				}
 			}

--- a/internal/provider/resource_ise_device_admin_condition.go
+++ b/internal/provider/resource_ise_device_admin_condition.go
@@ -268,10 +268,10 @@ func (r *DeviceAdminConditionResource) Schema(ctx context.Context, req resource.
 													NestedObject: schema.NestedAttributeObject{
 														Attributes: map[string]schema.Attribute{
 															"condition_type": schema.StringAttribute{
-																MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAttributes", "ConditionReference").String,
+																MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference").String,
 																Required:            true,
 																Validators: []validator.String{
-																	stringvalidator.OneOf("ConditionAttributes", "ConditionReference"),
+																	stringvalidator.OneOf("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference"),
 																},
 															},
 															"id": schema.StringAttribute{
@@ -303,6 +303,98 @@ func (r *DeviceAdminConditionResource) Schema(ctx context.Context, req resource.
 																Optional:            true,
 																Validators: []validator.String{
 																	stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																},
+															},
+															"children": schema.ListNestedAttribute{
+																MarkdownDescription: helpers.NewAttributeDescription("List of child conditions").String,
+																Optional:            true,
+																NestedObject: schema.NestedAttributeObject{
+																	Attributes: map[string]schema.Attribute{
+																		"condition_type": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference").String,
+																			Required:            true,
+																			Validators: []validator.String{
+																				stringvalidator.OneOf("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference"),
+																			},
+																		},
+																		"id": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("UUID for condition").String,
+																			Optional:            true,
+																		},
+																		"is_negate": schema.BoolAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Indicates whereas this condition is in negate mode").String,
+																			Optional:            true,
+																		},
+																		"attribute_name": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary attribute name").String,
+																			Optional:            true,
+																		},
+																		"attribute_value": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Attribute value for condition").String,
+																			Optional:            true,
+																		},
+																		"dictionary_name": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary name").String,
+																			Optional:            true,
+																		},
+																		"dictionary_value": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary value").String,
+																			Optional:            true,
+																		},
+																		"operator": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Equality operator").AddStringEnumDescription("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith").String,
+																			Optional:            true,
+																			Validators: []validator.String{
+																				stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																			},
+																		},
+																		"children": schema.ListNestedAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("List of child conditions").String,
+																			Optional:            true,
+																			NestedObject: schema.NestedAttributeObject{
+																				Attributes: map[string]schema.Attribute{
+																					"condition_type": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAttributes", "ConditionReference").String,
+																						Required:            true,
+																						Validators: []validator.String{
+																							stringvalidator.OneOf("ConditionAttributes", "ConditionReference"),
+																						},
+																					},
+																					"id": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("UUID for condition").String,
+																						Optional:            true,
+																					},
+																					"is_negate": schema.BoolAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Indicates whereas this condition is in negate mode").String,
+																						Optional:            true,
+																					},
+																					"attribute_name": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary attribute name").String,
+																						Optional:            true,
+																					},
+																					"attribute_value": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Attribute value for condition").String,
+																						Optional:            true,
+																					},
+																					"dictionary_name": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary name").String,
+																						Optional:            true,
+																					},
+																					"dictionary_value": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary value").String,
+																						Optional:            true,
+																					},
+																					"operator": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Equality operator").AddStringEnumDescription("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith").String,
+																						Optional:            true,
+																						Validators: []validator.String{
+																							stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
 																},
 															},
 														},

--- a/internal/provider/resource_ise_network_access_condition.go
+++ b/internal/provider/resource_ise_network_access_condition.go
@@ -268,10 +268,10 @@ func (r *NetworkAccessConditionResource) Schema(ctx context.Context, req resourc
 													NestedObject: schema.NestedAttributeObject{
 														Attributes: map[string]schema.Attribute{
 															"condition_type": schema.StringAttribute{
-																MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAttributes", "ConditionReference").String,
+																MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference").String,
 																Required:            true,
 																Validators: []validator.String{
-																	stringvalidator.OneOf("ConditionAttributes", "ConditionReference"),
+																	stringvalidator.OneOf("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference"),
 																},
 															},
 															"id": schema.StringAttribute{
@@ -303,6 +303,98 @@ func (r *NetworkAccessConditionResource) Schema(ctx context.Context, req resourc
 																Optional:            true,
 																Validators: []validator.String{
 																	stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																},
+															},
+															"children": schema.ListNestedAttribute{
+																MarkdownDescription: helpers.NewAttributeDescription("List of child conditions").String,
+																Optional:            true,
+																NestedObject: schema.NestedAttributeObject{
+																	Attributes: map[string]schema.Attribute{
+																		"condition_type": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference").String,
+																			Required:            true,
+																			Validators: []validator.String{
+																				stringvalidator.OneOf("ConditionAndBlock", "ConditionAttributes", "ConditionOrBlock", "ConditionReference"),
+																			},
+																		},
+																		"id": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("UUID for condition").String,
+																			Optional:            true,
+																		},
+																		"is_negate": schema.BoolAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Indicates whereas this condition is in negate mode").String,
+																			Optional:            true,
+																		},
+																		"attribute_name": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary attribute name").String,
+																			Optional:            true,
+																		},
+																		"attribute_value": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Attribute value for condition").String,
+																			Optional:            true,
+																		},
+																		"dictionary_name": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary name").String,
+																			Optional:            true,
+																		},
+																		"dictionary_value": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Dictionary value").String,
+																			Optional:            true,
+																		},
+																		"operator": schema.StringAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("Equality operator").AddStringEnumDescription("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith").String,
+																			Optional:            true,
+																			Validators: []validator.String{
+																				stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																			},
+																		},
+																		"children": schema.ListNestedAttribute{
+																			MarkdownDescription: helpers.NewAttributeDescription("List of child conditions").String,
+																			Optional:            true,
+																			NestedObject: schema.NestedAttributeObject{
+																				Attributes: map[string]schema.Attribute{
+																					"condition_type": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Condition type.").AddStringEnumDescription("ConditionAttributes", "ConditionReference").String,
+																						Required:            true,
+																						Validators: []validator.String{
+																							stringvalidator.OneOf("ConditionAttributes", "ConditionReference"),
+																						},
+																					},
+																					"id": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("UUID for condition").String,
+																						Optional:            true,
+																					},
+																					"is_negate": schema.BoolAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Indicates whereas this condition is in negate mode").String,
+																						Optional:            true,
+																					},
+																					"attribute_name": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary attribute name").String,
+																						Optional:            true,
+																					},
+																					"attribute_value": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Attribute value for condition").String,
+																						Optional:            true,
+																					},
+																					"dictionary_name": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary name").String,
+																						Optional:            true,
+																					},
+																					"dictionary_value": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Dictionary value").String,
+																						Optional:            true,
+																					},
+																					"operator": schema.StringAttribute{
+																						MarkdownDescription: helpers.NewAttributeDescription("Equality operator").AddStringEnumDescription("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith").String,
+																						Optional:            true,
+																						Validators: []validator.String{
+																							stringvalidator.OneOf("contains", "endsWith", "equals", "greaterOrEquals", "greaterThan", "in", "ipEquals", "ipGreaterThan", "ipLessThan", "ipNotEquals", "lessOrEquals", "lessThan", "matches", "notContains", "notEndsWith", "notEquals", "notIn", "notStartsWith", "startsWith"),
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
 																},
 															},
 														},


### PR DESCRIPTION
## Summary

Extends `children` nesting depth from 4 to 6 levels in `ise_device_admin_condition` and `ise_network_access_condition`, aligning the provider with the Terraform module and schema which already support 6 levels.

Closes #201

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~99% (YAML definitions + code regeneration)
- **AI Reason**: extend condition children nesting from 4 to 6 levels
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart