### PR TITLE
fix: prevent updateFromBody from matching same response item to multiple siblings

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -755,17 +755,24 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 	}
 	{{- else if and (isNestedListSet .) (not .Immutable) }}
 	{{- $list := (toGoName .TfName)}}
+	rUsed{{$list}} := make(map[int]bool)
 	for i := range data.{{toGoName .TfName}} {
 		keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 		keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		{{- if strContains (camelCase $.Name) "UpdateRanks" }}
 		res.Get("response").ForEach(
 		{{- else}}
 		res.{{if .ModelName}}Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}").{{end}}ForEach(
 		{{- end}}
 			func(_, v gjson.Result) bool {
+				if rUsed{{$list}}[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -777,11 +784,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsed{{$list}}[rIdx] = true
+		}
 
 		{{- range .Attributes}}
 		{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
@@ -805,13 +818,20 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 		}
 		{{- else if isNestedListSet .}}
 		{{- $clist := (toGoName .TfName)}}
+		crUsed := make(map[int]bool)
 		for ci := range data.{{$list}}[i].{{toGoName .TfName}} {
 			keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 			keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -823,11 +843,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 
 			{{- range .Attributes}}
 			{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
@@ -851,13 +877,20 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 			}
 			{{- else if isNestedListSet .}}
 			{{- $cclist := (toGoName .TfName)}}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.{{$list}}[i].{{$clist}}[ci].{{toGoName .TfName}} {
 				keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 				keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -869,11 +902,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 
 				{{- range .Attributes}}
 				{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
@@ -897,13 +936,20 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 				}
 				{{- else if isNestedListSet .}}
 				{{- $ccclist := (toGoName .TfName)}}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{toGoName .TfName}} {
 					keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 					keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -915,11 +961,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 
 					{{- range .Attributes}}
 					{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
@@ -943,13 +995,20 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 					}
 					{{- else if isNestedListSet .}}
 					{{- $cccclist := (toGoName .TfName)}}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{toGoName .TfName}} {
 						keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 						keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -961,11 +1020,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 
 						{{- range .Attributes}}
 						{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
@@ -989,13 +1054,20 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 						}
 						{{- else if isNestedListSet .}}
 						{{- $ccccclist := (toGoName .TfName)}}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{toGoName .TfName}} {
 							keys := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if or (eq .Type "Int64") (eq .Type "Bool") (eq .Type "String")}}"{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{end}}{{end}}{{end}} }
 							keyValues := [...]string{ {{$noId := not (hasId .Attributes)}}{{range .Attributes}}{{if or .Id (and $noId (not .Value))}}{{if eq .Type "Int64"}}strconv.FormatInt(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{$ccccclist}}[ccccci].{{toGoName .TfName}}.ValueInt64(), 10), {{else if eq .Type "Bool"}}strconv.FormatBool(data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{$ccccclist}}[ccccci].{{toGoName .TfName}}.ValueBool()), {{else if eq .Type "String"}}data.{{$list}}[i].{{$clist}}[ci].{{$cclist}}[cci].{{$ccclist}}[ccci].{{$cccclist}}[cccci].{{$ccccclist}}[ccccci].{{toGoName .TfName}}.Value{{.Type}}(), {{end}}{{end}}{{end}} }
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -1007,11 +1079,17 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 
 							{{- range .Attributes}}
 							{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}

--- a/internal/provider/model_ise_active_directory_add_groups.go
+++ b/internal/provider/model_ise_active_directory_add_groups.go
@@ -178,13 +178,20 @@ func (data *ActiveDirectoryAddGroups) updateFromBody(ctx context.Context, res gj
 	} else if data.EnableDomainAllowedList.ValueBool() != true {
 		data.EnableDomainAllowedList = types.BoolNull()
 	}
+	rUsedGroups := make(map[int]bool)
 	for i := range data.Groups {
 		keys := [...]string{"sid"}
 		keyValues := [...]string{data.Groups[i].Sid.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("ERSActiveDirectory.adgroups.groups").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedGroups[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -196,11 +203,17 @@ func (data *ActiveDirectoryAddGroups) updateFromBody(ctx context.Context, res gj
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedGroups[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Groups[i].Name.IsNull() {
 			data.Groups[i].Name = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_active_directory_groups_by_domain.go
+++ b/internal/provider/model_ise_active_directory_groups_by_domain.go
@@ -168,13 +168,20 @@ func (data *ActiveDirectoryGroupsByDomain) updateFromBody(ctx context.Context, r
 	} else {
 		data.TypeFilter = types.StringNull()
 	}
+	rUsedGroups := make(map[int]bool)
 	for i := range data.Groups {
 		keys := [...]string{"name", "sid", "type"}
 		keyValues := [...]string{data.Groups[i].Name.ValueString(), data.Groups[i].Sid.ValueString(), data.Groups[i].Type.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("ERSActiveDirectoryGroups.groups").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedGroups[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -186,11 +193,17 @@ func (data *ActiveDirectoryGroupsByDomain) updateFromBody(ctx context.Context, r
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedGroups[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Groups[i].Name.IsNull() {
 			data.Groups[i].Name = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_active_directory_join_domain_with_all_nodes.go
+++ b/internal/provider/model_ise_active_directory_join_domain_with_all_nodes.go
@@ -108,13 +108,20 @@ func (data *ActiveDirectoryJoinDomainWithAllNodes) fromBody(ctx context.Context,
 
 //template:begin updateFromBody
 func (data *ActiveDirectoryJoinDomainWithAllNodes) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedAdditionalData := make(map[int]bool)
 	for i := range data.AdditionalData {
 		keys := [...]string{"name"}
 		keyValues := [...]string{data.AdditionalData[i].Name.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("OperationAdditionalData.additionalData").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedAdditionalData[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -126,11 +133,17 @@ func (data *ActiveDirectoryJoinDomainWithAllNodes) updateFromBody(ctx context.Co
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedAdditionalData[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.AdditionalData[i].Name.IsNull() {
 			data.AdditionalData[i].Name = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_active_directory_join_point.go
+++ b/internal/provider/model_ise_active_directory_join_point.go
@@ -501,13 +501,20 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 	} else if data.EnableDomainAllowedList.ValueBool() != true {
 		data.EnableDomainAllowedList = types.BoolNull()
 	}
+	rUsedGroups := make(map[int]bool)
 	for i := range data.Groups {
 		keys := [...]string{"sid"}
 		keyValues := [...]string{data.Groups[i].Sid.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("ERSActiveDirectory.adgroups.groups").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedGroups[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -519,11 +526,17 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedGroups[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Groups[i].Name.IsNull() {
 			data.Groups[i].Name = types.StringValue(value.String())
 		} else {
@@ -535,13 +548,20 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 			data.Groups[i].Sid = types.StringNull()
 		}
 	}
+	rUsedAttributes := make(map[int]bool)
 	for i := range data.Attributes {
 		keys := [...]string{"name", "type", "internalName", "defaultValue"}
 		keyValues := [...]string{data.Attributes[i].Name.ValueString(), data.Attributes[i].Type.ValueString(), data.Attributes[i].InternalName.ValueString(), data.Attributes[i].DefaultValue.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("ERSActiveDirectory.adAttributes.attributes").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedAttributes[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -553,11 +573,17 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedAttributes[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Attributes[i].Name.IsNull() {
 			data.Attributes[i].Name = types.StringValue(value.String())
 		} else {
@@ -579,13 +605,20 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 			data.Attributes[i].DefaultValue = types.StringNull()
 		}
 	}
+	rUsedRewriteRules := make(map[int]bool)
 	for i := range data.RewriteRules {
 		keys := [...]string{"rowId", "rewriteMatch", "rewriteResult"}
 		keyValues := [...]string{data.RewriteRules[i].RowId.ValueString(), data.RewriteRules[i].RewriteMatch.ValueString(), data.RewriteRules[i].RewriteResult.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("ERSActiveDirectory.advancedSettings.rewriteRules").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRewriteRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -597,11 +630,17 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRewriteRules[rIdx] = true
+		}
 		if value := r.Get("rowId"); value.Exists() && !data.RewriteRules[i].RowId.IsNull() {
 			data.RewriteRules[i].RowId = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_authorization_profile.go
+++ b/internal/provider/model_ise_authorization_profile.go
@@ -577,13 +577,20 @@ func (data *AuthorizationProfile) updateFromBody(ctx context.Context, res gjson.
 	} else {
 		data.ReauthenticationTimer = types.Int64Null()
 	}
+	rUsedAdvancedAttributes := make(map[int]bool)
 	for i := range data.AdvancedAttributes {
 		keys := [...]string{"leftHandSideDictionaryAttribue.dictionaryName", "leftHandSideDictionaryAttribue.attributeName", "rightHandSideAttribueValue.AdvancedAttributeValueType", "rightHandSideAttribueValue.value", "rightHandSideAttribueValue.dictionaryName", "rightHandSideAttribueValue.attributeName"}
 		keyValues := [...]string{data.AdvancedAttributes[i].AttributeLeftDictionaryName.ValueString(), data.AdvancedAttributes[i].AttributeLeftName.ValueString(), data.AdvancedAttributes[i].AttributeRightValueType.ValueString(), data.AdvancedAttributes[i].AttributeRightValue.ValueString(), data.AdvancedAttributes[i].AttributeRightDictionaryName.ValueString(), data.AdvancedAttributes[i].AttributeRightName.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("AuthorizationProfile.advancedAttributes").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedAdvancedAttributes[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -595,11 +602,17 @@ func (data *AuthorizationProfile) updateFromBody(ctx context.Context, res gjson.
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedAdvancedAttributes[rIdx] = true
+		}
 		if value := r.Get("leftHandSideDictionaryAttribue.dictionaryName"); value.Exists() && !data.AdvancedAttributes[i].AttributeLeftDictionaryName.IsNull() {
 			data.AdvancedAttributes[i].AttributeLeftDictionaryName = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_device_admin_authentication_rule.go
+++ b/internal/provider/model_ise_device_admin_authentication_rule.go
@@ -674,13 +674,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -692,11 +699,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -737,13 +750,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -755,11 +775,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -800,13 +826,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -818,11 +851,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -863,13 +902,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -881,11 +927,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -926,13 +978,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -944,11 +1003,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -989,13 +1054,20 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -1007,11 +1079,17 @@ func (data *DeviceAdminAuthenticationRule) updateFromBody(ctx context.Context, r
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_authentication_rule_update_ranks.go
+++ b/internal/provider/model_ise_device_admin_authentication_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *DeviceAdminAuthenticationRuleUpdateRanks) fromBody(ctx context.Conte
 
 //template:begin updateFromBody
 func (data *DeviceAdminAuthenticationRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *DeviceAdminAuthenticationRuleUpdateRanks) updateFromBody(ctx context
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_device_admin_authorization_exception_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_exception_rule.go
@@ -659,13 +659,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -677,11 +684,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -722,13 +735,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -740,11 +760,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -785,13 +811,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -803,11 +836,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -848,13 +887,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -866,11 +912,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -911,13 +963,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -929,11 +988,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -974,13 +1039,20 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -992,11 +1064,17 @@ func (data *DeviceAdminAuthorizationExceptionRule) updateFromBody(ctx context.Co
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_authorization_exception_rule_update_ranks.go
+++ b/internal/provider/model_ise_device_admin_authorization_exception_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *DeviceAdminAuthorizationExceptionRuleUpdateRanks) fromBody(ctx conte
 
 //template:begin updateFromBody
 func (data *DeviceAdminAuthorizationExceptionRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *DeviceAdminAuthorizationExceptionRuleUpdateRanks) updateFromBody(ctx
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_device_admin_authorization_global_exception_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_global_exception_rule.go
@@ -642,13 +642,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -660,11 +667,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -705,13 +718,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -723,11 +743,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -768,13 +794,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -786,11 +819,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -831,13 +870,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -849,11 +895,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -894,13 +946,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -912,11 +971,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -957,13 +1022,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -975,11 +1047,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) updateFromBody(ctx cont
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_authorization_global_exception_rule_update_ranks.go
+++ b/internal/provider/model_ise_device_admin_authorization_global_exception_rule_update_ranks.go
@@ -102,13 +102,20 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRuleUpdateRanks) fromBody(ctx
 
 //template:begin updateFromBody
 func (data *DeviceAdminAuthorizationGlobalExceptionRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -120,11 +127,17 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRuleUpdateRanks) updateFromBo
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_device_admin_authorization_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_rule.go
@@ -659,13 +659,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -677,11 +684,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -722,13 +735,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -740,11 +760,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -785,13 +811,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -803,11 +836,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -848,13 +887,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -866,11 +912,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -911,13 +963,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -929,11 +988,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -974,13 +1039,20 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -992,11 +1064,17 @@ func (data *DeviceAdminAuthorizationRule) updateFromBody(ctx context.Context, re
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_authorization_rule_update_ranks.go
+++ b/internal/provider/model_ise_device_admin_authorization_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *DeviceAdminAuthorizationRuleUpdateRanks) fromBody(ctx context.Contex
 
 //template:begin updateFromBody
 func (data *DeviceAdminAuthorizationRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *DeviceAdminAuthorizationRuleUpdateRanks) updateFromBody(ctx context.
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_device_admin_condition.go
+++ b/internal/provider/model_ise_device_admin_condition.go
@@ -629,13 +629,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 	} else {
 		data.Operator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"name", "conditionType", "id", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].Name.ValueString(), data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -647,11 +654,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Children[i].Name.IsNull() {
 			data.Children[i].Name = types.StringValue(value.String())
 		} else {
@@ -702,13 +715,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"name", "conditionType", "id", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].Name.ValueString(), data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -720,11 +740,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("name"); value.Exists() && !data.Children[i].Children[ci].Name.IsNull() {
 				data.Children[i].Children[ci].Name = types.StringValue(value.String())
 			} else {
@@ -775,13 +801,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -793,11 +826,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -838,13 +877,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -856,11 +902,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -901,13 +953,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -919,11 +978,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -964,13 +1029,20 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -982,11 +1054,17 @@ func (data *DeviceAdminCondition) updateFromBody(ctx context.Context, res gjson.
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_policy_set.go
+++ b/internal/provider/model_ise_device_admin_policy_set.go
@@ -677,13 +677,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -695,11 +702,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -740,13 +753,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -758,11 +778,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -803,13 +829,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -821,11 +854,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -866,13 +905,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -884,11 +930,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -929,13 +981,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -947,11 +1006,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -992,13 +1057,20 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -1010,11 +1082,17 @@ func (data *DeviceAdminPolicySet) updateFromBody(ctx context.Context, res gjson.
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_device_admin_policy_set_update_ranks.go
+++ b/internal/provider/model_ise_device_admin_policy_set_update_ranks.go
@@ -102,13 +102,20 @@ func (data *DeviceAdminPolicySetUpdateRanks) fromBody(ctx context.Context, res g
 
 //template:begin updateFromBody
 func (data *DeviceAdminPolicySetUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedPolicies := make(map[int]bool)
 	for i := range data.Policies {
 		keys := [...]string{"id", "rank"}
 		keyValues := [...]string{data.Policies[i].Id.ValueString(), strconv.FormatInt(data.Policies[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedPolicies[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -120,11 +127,17 @@ func (data *DeviceAdminPolicySetUpdateRanks) updateFromBody(ctx context.Context,
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedPolicies[rIdx] = true
+		}
 		if value := r.Get("id"); value.Exists() && !data.Policies[i].Id.IsNull() {
 			data.Policies[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_identity_source_sequence.go
+++ b/internal/provider/model_ise_identity_source_sequence.go
@@ -158,13 +158,20 @@ func (data *IdentitySourceSequence) updateFromBody(ctx context.Context, res gjso
 	} else {
 		data.CertificateAuthenticationProfile = types.StringNull()
 	}
+	rUsedIdentitySources := make(map[int]bool)
 	for i := range data.IdentitySources {
 		keys := [...]string{"idstore", "order"}
 		keyValues := [...]string{data.IdentitySources[i].Name.ValueString(), strconv.FormatInt(data.IdentitySources[i].Order.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("IdStoreSequence.idSeqItem").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedIdentitySources[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -176,11 +183,17 @@ func (data *IdentitySourceSequence) updateFromBody(ctx context.Context, res gjso
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedIdentitySources[rIdx] = true
+		}
 		if value := r.Get("idstore"); value.Exists() && !data.IdentitySources[i].Name.IsNull() {
 			data.IdentitySources[i].Name = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_license_tier_state.go
+++ b/internal/provider/model_ise_license_tier_state.go
@@ -101,13 +101,20 @@ func (data *LicenseTierState) fromBody(ctx context.Context, res gjson.Result) {
 
 //template:begin updateFromBody
 func (data *LicenseTierState) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedLicenses := make(map[int]bool)
 	for i := range data.Licenses {
 		keys := [...]string{"name"}
 		keyValues := [...]string{data.Licenses[i].Name.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedLicenses[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -119,11 +126,17 @@ func (data *LicenseTierState) updateFromBody(ctx context.Context, res gjson.Resu
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedLicenses[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Licenses[i].Name.IsNull() {
 			data.Licenses[i].Name = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_authentication_rule.go
+++ b/internal/provider/model_ise_network_access_authentication_rule.go
@@ -674,13 +674,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -692,11 +699,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -737,13 +750,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -755,11 +775,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -800,13 +826,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -818,11 +851,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -863,13 +902,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -881,11 +927,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -926,13 +978,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -944,11 +1003,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -989,13 +1054,20 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -1007,11 +1079,17 @@ func (data *NetworkAccessAuthenticationRule) updateFromBody(ctx context.Context,
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_authentication_rule_update_ranks.go
+++ b/internal/provider/model_ise_network_access_authentication_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *NetworkAccessAuthenticationRuleUpdateRanks) fromBody(ctx context.Con
 
 //template:begin updateFromBody
 func (data *NetworkAccessAuthenticationRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *NetworkAccessAuthenticationRuleUpdateRanks) updateFromBody(ctx conte
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_authorization_exception_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_exception_rule.go
@@ -659,13 +659,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -677,11 +684,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -722,13 +735,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -740,11 +760,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -785,13 +811,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -803,11 +836,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -848,13 +887,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -866,11 +912,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -911,13 +963,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -929,11 +988,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -974,13 +1039,20 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -992,11 +1064,17 @@ func (data *NetworkAccessAuthorizationExceptionRule) updateFromBody(ctx context.
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_authorization_exception_rule_update_ranks.go
+++ b/internal/provider/model_ise_network_access_authorization_exception_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *NetworkAccessAuthorizationExceptionRuleUpdateRanks) fromBody(ctx con
 
 //template:begin updateFromBody
 func (data *NetworkAccessAuthorizationExceptionRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *NetworkAccessAuthorizationExceptionRuleUpdateRanks) updateFromBody(c
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_authorization_global_exception_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_global_exception_rule.go
@@ -642,13 +642,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -660,11 +667,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -705,13 +718,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -723,11 +743,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -768,13 +794,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -786,11 +819,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -831,13 +870,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -849,11 +895,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -894,13 +946,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -912,11 +971,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -957,13 +1022,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -975,11 +1047,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) updateFromBody(ctx co
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_authorization_global_exception_rule_update_ranks.go
+++ b/internal/provider/model_ise_network_access_authorization_global_exception_rule_update_ranks.go
@@ -102,13 +102,20 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRuleUpdateRanks) fromBody(c
 
 //template:begin updateFromBody
 func (data *NetworkAccessAuthorizationGlobalExceptionRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -120,11 +127,17 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRuleUpdateRanks) updateFrom
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_authorization_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_rule.go
@@ -659,13 +659,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.rule.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -677,11 +684,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -722,13 +735,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -740,11 +760,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -785,13 +811,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -803,11 +836,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -848,13 +887,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -866,11 +912,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -911,13 +963,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -929,11 +988,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -974,13 +1039,20 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -992,11 +1064,17 @@ func (data *NetworkAccessAuthorizationRule) updateFromBody(ctx context.Context, 
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_authorization_rule_update_ranks.go
+++ b/internal/provider/model_ise_network_access_authorization_rule_update_ranks.go
@@ -105,13 +105,20 @@ func (data *NetworkAccessAuthorizationRuleUpdateRanks) fromBody(ctx context.Cont
 
 //template:begin updateFromBody
 func (data *NetworkAccessAuthorizationRuleUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedRules := make(map[int]bool)
 	for i := range data.Rules {
 		keys := [...]string{"rule.id", "rule.rank"}
 		keyValues := [...]string{data.Rules[i].Id.ValueString(), strconv.FormatInt(data.Rules[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedRules[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -123,11 +130,17 @@ func (data *NetworkAccessAuthorizationRuleUpdateRanks) updateFromBody(ctx contex
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedRules[rIdx] = true
+		}
 		if value := r.Get("rule.id"); value.Exists() && !data.Rules[i].Id.IsNull() {
 			data.Rules[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_condition.go
+++ b/internal/provider/model_ise_network_access_condition.go
@@ -629,13 +629,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 	} else {
 		data.Operator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"name", "conditionType", "id", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].Name.ValueString(), data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -647,11 +654,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("name"); value.Exists() && !data.Children[i].Name.IsNull() {
 			data.Children[i].Name = types.StringValue(value.String())
 		} else {
@@ -702,13 +715,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"name", "conditionType", "id", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].Name.ValueString(), data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -720,11 +740,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("name"); value.Exists() && !data.Children[i].Children[ci].Name.IsNull() {
 				data.Children[i].Children[ci].Name = types.StringValue(value.String())
 			} else {
@@ -775,13 +801,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -793,11 +826,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -838,13 +877,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -856,11 +902,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -901,13 +953,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -919,11 +978,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -964,13 +1029,20 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -982,11 +1054,17 @@ func (data *NetworkAccessCondition) updateFromBody(ctx context.Context, res gjso
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_dictionary_attribute.go
+++ b/internal/provider/model_ise_network_access_dictionary_attribute.go
@@ -174,13 +174,20 @@ func (data *NetworkAccessDictionaryAttribute) updateFromBody(ctx context.Context
 	} else {
 		data.InternalName = types.StringNull()
 	}
+	rUsedAllowedValues := make(map[int]bool)
 	for i := range data.AllowedValues {
 		keys := [...]string{"key", "value"}
 		keyValues := [...]string{data.AllowedValues[i].Key.ValueString(), data.AllowedValues[i].Value.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.allowedValues").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedAllowedValues[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -192,11 +199,17 @@ func (data *NetworkAccessDictionaryAttribute) updateFromBody(ctx context.Context
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedAllowedValues[rIdx] = true
+		}
 		if value := r.Get("key"); value.Exists() && !data.AllowedValues[i].Key.IsNull() {
 			data.AllowedValues[i].Key = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_access_policy_set.go
+++ b/internal/provider/model_ise_network_access_policy_set.go
@@ -677,13 +677,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 	} else {
 		data.ConditionOperator = types.StringNull()
 	}
+	rUsedChildren := make(map[int]bool)
 	for i := range data.Children {
 		keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 		keyValues := [...]string{data.Children[i].ConditionType.ValueString(), data.Children[i].Id.ValueString(), strconv.FormatBool(data.Children[i].IsNegate.ValueBool()), data.Children[i].AttributeName.ValueString(), data.Children[i].AttributeValue.ValueString(), data.Children[i].DictionaryName.ValueString(), data.Children[i].DictionaryValue.ValueString(), data.Children[i].Operator.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response.condition.children").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedChildren[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -695,11 +702,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedChildren[rIdx] = true
+		}
 		if value := r.Get("conditionType"); value.Exists() && !data.Children[i].ConditionType.IsNull() {
 			data.Children[i].ConditionType = types.StringValue(value.String())
 		} else {
@@ -740,13 +753,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 		} else {
 			data.Children[i].Operator = types.StringNull()
 		}
+		crUsed := make(map[int]bool)
 		for ci := range data.Children[i].Children {
 			keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 			keyValues := [...]string{data.Children[i].Children[ci].ConditionType.ValueString(), data.Children[i].Children[ci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].IsNegate.ValueBool()), data.Children[i].Children[ci].AttributeName.ValueString(), data.Children[i].Children[ci].AttributeValue.ValueString(), data.Children[i].Children[ci].DictionaryName.ValueString(), data.Children[i].Children[ci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Operator.ValueString()}
 
 			var cr gjson.Result
+			crIdx := -1
+			crSearchIdx := 0
 			r.Get("children").ForEach(
 				func(_, v gjson.Result) bool {
+					if crUsed[crSearchIdx] {
+						crSearchIdx++
+						return true
+					}
 					found := false
 					for ik := range keys {
 						if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -758,11 +778,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 					}
 					if found {
 						cr = v
+						crIdx = crSearchIdx
+						crSearchIdx++
 						return false
 					}
+					crSearchIdx++
 					return true
 				},
 			)
+			if crIdx >= 0 {
+				crUsed[crIdx] = true
+			}
 			if value := cr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].ConditionType.IsNull() {
 				data.Children[i].Children[ci].ConditionType = types.StringValue(value.String())
 			} else {
@@ -803,13 +829,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 			} else {
 				data.Children[i].Children[ci].Operator = types.StringNull()
 			}
+			ccrUsed := make(map[int]bool)
 			for cci := range data.Children[i].Children[ci].Children {
 				keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 				keyValues := [...]string{data.Children[i].Children[ci].Children[cci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Operator.ValueString()}
 
 				var ccr gjson.Result
+				ccrIdx := -1
+				ccrSearchIdx := 0
 				cr.Get("children").ForEach(
 					func(_, v gjson.Result) bool {
+						if ccrUsed[ccrSearchIdx] {
+							ccrSearchIdx++
+							return true
+						}
 						found := false
 						for ik := range keys {
 							if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -821,11 +854,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 						}
 						if found {
 							ccr = v
+							ccrIdx = ccrSearchIdx
+							ccrSearchIdx++
 							return false
 						}
+						ccrSearchIdx++
 						return true
 					},
 				)
+				if ccrIdx >= 0 {
+					ccrUsed[ccrIdx] = true
+				}
 				if value := ccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].ConditionType.IsNull() {
 					data.Children[i].Children[ci].Children[cci].ConditionType = types.StringValue(value.String())
 				} else {
@@ -866,13 +905,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 				} else {
 					data.Children[i].Children[ci].Children[cci].Operator = types.StringNull()
 				}
+				cccrUsed := make(map[int]bool)
 				for ccci := range data.Children[i].Children[ci].Children[cci].Children {
 					keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 					keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Operator.ValueString()}
 
 					var cccr gjson.Result
+					cccrIdx := -1
+					cccrSearchIdx := 0
 					ccr.Get("children").ForEach(
 						func(_, v gjson.Result) bool {
+							if cccrUsed[cccrSearchIdx] {
+								cccrSearchIdx++
+								return true
+							}
 							found := false
 							for ik := range keys {
 								if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -884,11 +930,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 							}
 							if found {
 								cccr = v
+								cccrIdx = cccrSearchIdx
+								cccrSearchIdx++
 								return false
 							}
+							cccrSearchIdx++
 							return true
 						},
 					)
+					if cccrIdx >= 0 {
+						cccrUsed[cccrIdx] = true
+					}
 					if value := cccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType.IsNull() {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].ConditionType = types.StringValue(value.String())
 					} else {
@@ -929,13 +981,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 					} else {
 						data.Children[i].Children[ci].Children[cci].Children[ccci].Operator = types.StringNull()
 					}
+					ccccrUsed := make(map[int]bool)
 					for cccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children {
 						keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 						keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator.ValueString()}
 
 						var ccccr gjson.Result
+						ccccrIdx := -1
+						ccccrSearchIdx := 0
 						cccr.Get("children").ForEach(
 							func(_, v gjson.Result) bool {
+								if ccccrUsed[ccccrSearchIdx] {
+									ccccrSearchIdx++
+									return true
+								}
 								found := false
 								for ik := range keys {
 									if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -947,11 +1006,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 								}
 								if found {
 									ccccr = v
+									ccccrIdx = ccccrSearchIdx
+									ccccrSearchIdx++
 									return false
 								}
+								ccccrSearchIdx++
 								return true
 							},
 						)
+						if ccccrIdx >= 0 {
+							ccccrUsed[ccccrIdx] = true
+						}
 						if value := ccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType.IsNull() {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].ConditionType = types.StringValue(value.String())
 						} else {
@@ -992,13 +1057,20 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 						} else {
 							data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Operator = types.StringNull()
 						}
+						cccccrUsed := make(map[int]bool)
 						for ccccci := range data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children {
 							keys := [...]string{"conditionType", "id", "isNegate", "attributeName", "attributeValue", "dictionaryName", "dictionaryValue", "operator"}
 							keyValues := [...]string{data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Id.ValueString(), strconv.FormatBool(data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].IsNegate.ValueBool()), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].AttributeValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryName.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].DictionaryValue.ValueString(), data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].Operator.ValueString()}
 
 							var cccccr gjson.Result
+							cccccrIdx := -1
+							cccccrSearchIdx := 0
 							ccccr.Get("children").ForEach(
 								func(_, v gjson.Result) bool {
+									if cccccrUsed[cccccrSearchIdx] {
+										cccccrSearchIdx++
+										return true
+									}
 									found := false
 									for ik := range keys {
 										if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -1010,11 +1082,17 @@ func (data *NetworkAccessPolicySet) updateFromBody(ctx context.Context, res gjso
 									}
 									if found {
 										cccccr = v
+										cccccrIdx = cccccrSearchIdx
+										cccccrSearchIdx++
 										return false
 									}
+									cccccrSearchIdx++
 									return true
 								},
 							)
+							if cccccrIdx >= 0 {
+								cccccrUsed[cccccrIdx] = true
+							}
 							if value := cccccr.Get("conditionType"); value.Exists() && !data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType.IsNull() {
 								data.Children[i].Children[ci].Children[cci].Children[ccci].Children[cccci].Children[ccccci].ConditionType = types.StringValue(value.String())
 							} else {

--- a/internal/provider/model_ise_network_access_policy_set_update_ranks.go
+++ b/internal/provider/model_ise_network_access_policy_set_update_ranks.go
@@ -102,13 +102,20 @@ func (data *NetworkAccessPolicySetUpdateRanks) fromBody(ctx context.Context, res
 
 //template:begin updateFromBody
 func (data *NetworkAccessPolicySetUpdateRanks) updateFromBody(ctx context.Context, res gjson.Result) {
+	rUsedPolicies := make(map[int]bool)
 	for i := range data.Policies {
 		keys := [...]string{"id", "rank"}
 		keyValues := [...]string{data.Policies[i].Id.ValueString(), strconv.FormatInt(data.Policies[i].Rank.ValueInt64(), 10)}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("response").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedPolicies[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -120,11 +127,17 @@ func (data *NetworkAccessPolicySetUpdateRanks) updateFromBody(ctx context.Contex
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedPolicies[rIdx] = true
+		}
 		if value := r.Get("id"); value.Exists() && !data.Policies[i].Id.IsNull() {
 			data.Policies[i].Id = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -599,13 +599,20 @@ func (data *NetworkDevice) updateFromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.DtlsDnsName = types.StringNull()
 	}
+	rUsedIps := make(map[int]bool)
 	for i := range data.Ips {
 		keys := [...]string{"ipaddress"}
 		keyValues := [...]string{data.Ips[i].Ipaddress.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("NetworkDevice.NetworkDeviceIPList").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedIps[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -617,11 +624,17 @@ func (data *NetworkDevice) updateFromBody(ctx context.Context, res gjson.Result)
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedIps[rIdx] = true
+		}
 		if value := r.Get("ipaddress"); value.Exists() && !data.Ips[i].Ipaddress.IsNull() {
 			data.Ips[i].Ipaddress = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_tacacs_command_set.go
+++ b/internal/provider/model_ise_tacacs_command_set.go
@@ -152,13 +152,20 @@ func (data *TACACSCommandSet) updateFromBody(ctx context.Context, res gjson.Resu
 	} else if data.PermitUnmatched.ValueBool() != false {
 		data.PermitUnmatched = types.BoolNull()
 	}
+	rUsedCommands := make(map[int]bool)
 	for i := range data.Commands {
 		keys := [...]string{"grant", "command", "arguments"}
 		keyValues := [...]string{data.Commands[i].Grant.ValueString(), data.Commands[i].Command.ValueString(), data.Commands[i].Arguments.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("TacacsCommandSets.commands.commandList").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedCommands[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -170,11 +177,17 @@ func (data *TACACSCommandSet) updateFromBody(ctx context.Context, res gjson.Resu
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedCommands[rIdx] = true
+		}
 		if value := r.Get("grant"); value.Exists() && !data.Commands[i].Grant.IsNull() {
 			data.Commands[i].Grant = types.StringValue(value.String())
 		} else {

--- a/internal/provider/model_ise_tacacs_profile.go
+++ b/internal/provider/model_ise_tacacs_profile.go
@@ -138,13 +138,20 @@ func (data *TACACSProfile) updateFromBody(ctx context.Context, res gjson.Result)
 	} else {
 		data.Description = types.StringNull()
 	}
+	rUsedSessionAttributes := make(map[int]bool)
 	for i := range data.SessionAttributes {
 		keys := [...]string{"type", "name", "value"}
 		keyValues := [...]string{data.SessionAttributes[i].Type.ValueString(), data.SessionAttributes[i].Name.ValueString(), data.SessionAttributes[i].Value.ValueString()}
 
 		var r gjson.Result
+		rIdx := -1
+		rSearchIdx := 0
 		res.Get("TacacsProfile.sessionAttributes.sessionAttributeList").ForEach(
 			func(_, v gjson.Result) bool {
+				if rUsedSessionAttributes[rSearchIdx] {
+					rSearchIdx++
+					return true
+				}
 				found := false
 				for ik := range keys {
 					if v.Get(keys[ik]).String() == keyValues[ik] {
@@ -156,11 +163,17 @@ func (data *TACACSProfile) updateFromBody(ctx context.Context, res gjson.Result)
 				}
 				if found {
 					r = v
+					rIdx = rSearchIdx
+					rSearchIdx++
 					return false
 				}
+				rSearchIdx++
 				return true
 			},
 		)
+		if rIdx >= 0 {
+			rUsedSessionAttributes[rIdx] = true
+		}
 		if value := r.Get("type"); value.Exists() && !data.SessionAttributes[i].Type.IsNull() {
 			data.SessionAttributes[i].Type = types.StringValue(value.String())
 		} else {


### PR DESCRIPTION
## Summary

- Fix idempotency bug in `updateFromBody` where multiple sibling `ConditionAndBlock`/`ConditionOrBlock` nodes at the same nesting level would all match against the same API response item, causing perpetual state drift
- Track consumed response indices at each nesting level so the same response item cannot be matched by multiple state items

## Problem

The `updateFromBody` function uses key-based matching to correlate Terraform state items with ISE API response items. When multiple sibling condition blocks exist at the same level (e.g., three `ConditionAndBlock` children under a `ConditionOrBlock`), they share identical key fingerprints — only `conditionType` is populated while all other keys (`attributeName`, `attributeValue`, etc.) are empty strings.

The search stops at the **first match**, so the 2nd and 3rd siblings are matched against the **same** response item as the 1st. Their nested children then fail to find matching attributes in the wrong response subtree, resulting in `null` state values and perpetual plan drift.

## Reproducer

```yaml
# ISE library condition with 3 sibling ConditionAndBlocks
- name: SIBLING_REPRO
  type: LibraryConditionOrBlock
  is_negate: false
  children:
    - type: ConditionAndBlock
      is_negate: false
      children:
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: User
          operator: equals
          attribute_value: admin1
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: Remote-Address
          operator: ipEquals
          attribute_value: 192.0.2.1
    - type: ConditionAndBlock
      is_negate: false
      children:
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: User
          operator: equals
          attribute_value: admin2
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: Remote-Address
          operator: ipEquals
          attribute_value: 198.51.100.1
    - type: ConditionAndBlock
      is_negate: false
      children:
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: User
          operator: equals
          attribute_value: admin3
        - type: ConditionAttributes
          dictionary_name: TACACS
          attribute_name: Remote-Address
          operator: ipEquals
          attribute_value: 203.0.113.1
```

**Symptom:** `terraform apply` succeeds, but every subsequent `terraform plan` shows the 2nd and 3rd `ConditionAndBlock` children wanting to be re-added (perpetual drift).

## Fix

Track which response items have already been "consumed" by a prior state item during the ForEach matching loop. When a match is found, its index is recorded. Subsequent iterations skip consumed indices, ensuring each state item maps to a unique response item.

Applied at all 6 nesting levels in the `updateFromBody` template.

## Test plan

- [x] `go build` passes
- [x] Integration tested against ISE 3.3 (162 resources created, full idempotency confirmed on second plan)
- [ ] Provider acceptance tests pass

## Related

- Complements #207 (fromBody depth extension for update_ranks)