### PR TITLE
fix: extend fromBody template to 6-level nesting depth

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -680,6 +680,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 						ccValue.ForEach(func(cck, ccv gjson.Result) bool {
 							ccItem := {{$name}}{{$cname}}{{$ccname}}{{toGoName .TfName}}{}
 							{{- range .Attributes}}
+							{{- $cccname := toGoName .TfName}}
 							{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 							{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 							if cccValue := ccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccValue.Exists() && cccValue.Type != gjson.Null {
@@ -702,6 +703,116 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 								ccItem.{{toGoName .TfName}} = helpers.GetStringMap(cccValue.Map())
 							} else {
 								ccItem.{{toGoName .TfName}} = types.MapNull(types.StringType)
+							}
+							{{- else if isNestedListSet .}}
+							if cccValue := ccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccValue.Exists() {
+								ccItem.{{toGoName .TfName}} = make([]{{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{toGoName .TfName}}, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := {{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{toGoName .TfName}}{}
+									{{- range .Attributes}}
+									{{- $ccccname := toGoName .TfName}}
+									{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+									{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
+									if ccccValue := cccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.{{toGoName .TfName}} = types.{{.Type}}Value(ccccValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
+									} else {
+										{{- if .DefaultValue}}
+										cccItem.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
+										{{- else}}
+										cccItem.{{toGoName .TfName}} = types.{{.Type}}Null()
+										{{- end}}
+									}
+									{{- else if isListSet .}}
+									if ccccValue := cccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccccValue.Exists() {
+										cccItem.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(ccccValue.Array())
+									} else {
+										cccItem.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
+									}
+									{{- else if eq .Type "Map"}}
+									if ccccValue := cccv.Get("{{if .DataPath}}{{.DataPath}}.{{end}}{{.ModelName}}"); ccccValue.Exists() {
+										cccItem.{{toGoName .TfName}} = helpers.GetStringMap(ccccValue.Map())
+									} else {
+										cccItem.{{toGoName .TfName}} = types.MapNull(types.StringType)
+									}
+									{{- else if isNestedListSet .}}
+									if ccccValue := cccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccccValue.Exists() {
+										cccItem.{{toGoName .TfName}} = make([]{{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{$ccccname}}{{toGoName .TfName}}, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := {{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{$ccccname}}{{toGoName .TfName}}{}
+											{{- range .Attributes}}
+											{{- $cccccname := toGoName .TfName}}
+											{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+											{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
+											if cccccValue := ccccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.{{toGoName .TfName}} = types.{{.Type}}Value(cccccValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
+											} else {
+												{{- if .DefaultValue}}
+												ccccItem.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
+												{{- else}}
+												ccccItem.{{toGoName .TfName}} = types.{{.Type}}Null()
+												{{- end}}
+											}
+											{{- else if isListSet .}}
+											if cccccValue := ccccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccccValue.Exists() {
+												ccccItem.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(cccccValue.Array())
+											} else {
+												ccccItem.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
+											}
+											{{- else if eq .Type "Map"}}
+											if cccccValue := ccccv.Get("{{if .DataPath}}{{.DataPath}}.{{end}}{{.ModelName}}"); cccccValue.Exists() {
+												ccccItem.{{toGoName .TfName}} = helpers.GetStringMap(cccccValue.Map())
+											} else {
+												ccccItem.{{toGoName .TfName}} = types.MapNull(types.StringType)
+											}
+											{{- else if isNestedListSet .}}
+											if cccccValue := ccccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); cccccValue.Exists() {
+												ccccItem.{{toGoName .TfName}} = make([]{{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{$ccccname}}{{$cccccname}}{{toGoName .TfName}}, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := {{$name}}{{$cname}}{{$ccname}}{{$cccname}}{{$ccccname}}{{$cccccname}}{{toGoName .TfName}}{}
+													{{- range .Attributes}}
+													{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
+													{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
+													if ccccccValue := cccccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.{{toGoName .TfName}} = types.{{.Type}}Value(ccccccValue.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
+													} else {
+														{{- if .DefaultValue}}
+														cccccItem.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
+														{{- else}}
+														cccccItem.{{toGoName .TfName}} = types.{{.Type}}Null()
+														{{- end}}
+													}
+													{{- else if isListSet .}}
+													if ccccccValue := cccccv.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); ccccccValue.Exists() {
+														cccccItem.{{toGoName .TfName}} = helpers.Get{{.ElementType}}{{.Type}}(ccccccValue.Array())
+													} else {
+														cccccItem.{{toGoName .TfName}} = types.{{.Type}}Null(types.{{.ElementType}}Type)
+													}
+													{{- else if eq .Type "Map"}}
+													if ccccccValue := cccccv.Get("{{if .DataPath}}{{.DataPath}}.{{end}}{{.ModelName}}"); ccccccValue.Exists() {
+														cccccItem.{{toGoName .TfName}} = helpers.GetStringMap(ccccccValue.Map())
+													} else {
+														cccccItem.{{toGoName .TfName}} = types.MapNull(types.StringType)
+													}
+													{{- end}}
+													{{- end}}
+													{{- end}}
+													ccccItem.{{toGoName .TfName}} = append(ccccItem.{{toGoName .TfName}}, cccccItem)
+													return true
+												})
+											}
+											{{- end}}
+											{{- end}}
+											{{- end}}
+											cccItem.{{toGoName .TfName}} = append(cccItem.{{toGoName .TfName}}, ccccItem)
+											return true
+										})
+									}
+									{{- end}}
+									{{- end}}
+									{{- end}}
+									ccItem.{{toGoName .TfName}} = append(ccItem.{{toGoName .TfName}}, cccItem)
+									return true
+								})
 							}
 							{{- end}}
 							{{- end}}

--- a/internal/provider/model_ise_device_admin_authentication_rule.go
+++ b/internal/provider/model_ise_device_admin_authentication_rule.go
@@ -576,6 +576,150 @@ func (data *DeviceAdminAuthenticationRule) fromBody(ctx context.Context, res gjs
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminAuthenticationRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_device_admin_authorization_exception_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_exception_rule.go
@@ -571,6 +571,150 @@ func (data *DeviceAdminAuthorizationExceptionRule) fromBody(ctx context.Context,
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_device_admin_authorization_global_exception_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_global_exception_rule.go
@@ -559,6 +559,150 @@ func (data *DeviceAdminAuthorizationGlobalExceptionRule) fromBody(ctx context.Co
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_device_admin_authorization_rule.go
+++ b/internal/provider/model_ise_device_admin_authorization_rule.go
@@ -571,6 +571,150 @@ func (data *DeviceAdminAuthorizationRule) fromBody(ctx context.Context, res gjso
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminAuthorizationRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_device_admin_condition.go
+++ b/internal/provider/model_ise_device_admin_condition.go
@@ -566,6 +566,150 @@ func (data *DeviceAdminCondition) fromBody(ctx context.Context, res gjson.Result
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminConditionChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminConditionChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminConditionChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminConditionChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminConditionChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminConditionChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_device_admin_policy_set.go
+++ b/internal/provider/model_ise_device_admin_policy_set.go
@@ -584,6 +584,150 @@ func (data *DeviceAdminPolicySet) fromBody(ctx context.Context, res gjson.Result
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]DeviceAdminPolicySetChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := DeviceAdminPolicySetChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]DeviceAdminPolicySetChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := DeviceAdminPolicySetChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]DeviceAdminPolicySetChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := DeviceAdminPolicySetChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_authentication_rule.go
+++ b/internal/provider/model_ise_network_access_authentication_rule.go
@@ -576,6 +576,150 @@ func (data *NetworkAccessAuthenticationRule) fromBody(ctx context.Context, res g
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessAuthenticationRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_authorization_exception_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_exception_rule.go
@@ -571,6 +571,150 @@ func (data *NetworkAccessAuthorizationExceptionRule) fromBody(ctx context.Contex
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessAuthorizationExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_authorization_global_exception_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_global_exception_rule.go
@@ -559,6 +559,150 @@ func (data *NetworkAccessAuthorizationGlobalExceptionRule) fromBody(ctx context.
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessAuthorizationGlobalExceptionRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_authorization_rule.go
+++ b/internal/provider/model_ise_network_access_authorization_rule.go
@@ -571,6 +571,150 @@ func (data *NetworkAccessAuthorizationRule) fromBody(ctx context.Context, res gj
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessAuthorizationRuleChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_condition.go
+++ b/internal/provider/model_ise_network_access_condition.go
@@ -566,6 +566,150 @@ func (data *NetworkAccessCondition) fromBody(ctx context.Context, res gjson.Resu
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessConditionChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessConditionChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessConditionChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessConditionChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessConditionChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessConditionChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})

--- a/internal/provider/model_ise_network_access_policy_set.go
+++ b/internal/provider/model_ise_network_access_policy_set.go
@@ -584,6 +584,150 @@ func (data *NetworkAccessPolicySet) fromBody(ctx context.Context, res gjson.Resu
 							} else {
 								ccItem.Operator = types.StringNull()
 							}
+							if cccValue := ccv.Get("children"); cccValue.Exists() {
+								ccItem.Children = make([]NetworkAccessPolicySetChildrenChildrenChildrenChildren, 0)
+								cccValue.ForEach(func(ccck, cccv gjson.Result) bool {
+									cccItem := NetworkAccessPolicySetChildrenChildrenChildrenChildren{}
+									if ccccValue := cccv.Get("conditionType"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.ConditionType = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.ConditionType = types.StringNull()
+									}
+									if ccccValue := cccv.Get("id"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Id = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Id = types.StringNull()
+									}
+									if ccccValue := cccv.Get("isNegate"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.IsNegate = types.BoolValue(ccccValue.Bool())
+									} else {
+										cccItem.IsNegate = types.BoolNull()
+									}
+									if ccccValue := cccv.Get("attributeName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("attributeValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.AttributeValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.AttributeValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryName"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryName = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryName = types.StringNull()
+									}
+									if ccccValue := cccv.Get("dictionaryValue"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.DictionaryValue = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.DictionaryValue = types.StringNull()
+									}
+									if ccccValue := cccv.Get("operator"); ccccValue.Exists() && ccccValue.Type != gjson.Null {
+										cccItem.Operator = types.StringValue(ccccValue.String())
+									} else {
+										cccItem.Operator = types.StringNull()
+									}
+									if ccccValue := cccv.Get("children"); ccccValue.Exists() {
+										cccItem.Children = make([]NetworkAccessPolicySetChildrenChildrenChildrenChildrenChildren, 0)
+										ccccValue.ForEach(func(cccck, ccccv gjson.Result) bool {
+											ccccItem := NetworkAccessPolicySetChildrenChildrenChildrenChildrenChildren{}
+											if cccccValue := ccccv.Get("conditionType"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.ConditionType = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.ConditionType = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("id"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Id = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Id = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("isNegate"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.IsNegate = types.BoolValue(cccccValue.Bool())
+											} else {
+												ccccItem.IsNegate = types.BoolNull()
+											}
+											if cccccValue := ccccv.Get("attributeName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("attributeValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.AttributeValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.AttributeValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryName"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryName = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryName = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("dictionaryValue"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.DictionaryValue = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.DictionaryValue = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("operator"); cccccValue.Exists() && cccccValue.Type != gjson.Null {
+												ccccItem.Operator = types.StringValue(cccccValue.String())
+											} else {
+												ccccItem.Operator = types.StringNull()
+											}
+											if cccccValue := ccccv.Get("children"); cccccValue.Exists() {
+												ccccItem.Children = make([]NetworkAccessPolicySetChildrenChildrenChildrenChildrenChildrenChildren, 0)
+												cccccValue.ForEach(func(ccccck, cccccv gjson.Result) bool {
+													cccccItem := NetworkAccessPolicySetChildrenChildrenChildrenChildrenChildrenChildren{}
+													if ccccccValue := cccccv.Get("conditionType"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.ConditionType = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.ConditionType = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("id"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Id = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Id = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("isNegate"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.IsNegate = types.BoolValue(ccccccValue.Bool())
+													} else {
+														cccccItem.IsNegate = types.BoolNull()
+													}
+													if ccccccValue := cccccv.Get("attributeName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("attributeValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.AttributeValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.AttributeValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryName"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryName = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryName = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("dictionaryValue"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.DictionaryValue = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.DictionaryValue = types.StringNull()
+													}
+													if ccccccValue := cccccv.Get("operator"); ccccccValue.Exists() && ccccccValue.Type != gjson.Null {
+														cccccItem.Operator = types.StringValue(ccccccValue.String())
+													} else {
+														cccccItem.Operator = types.StringNull()
+													}
+													ccccItem.Children = append(ccccItem.Children, cccccItem)
+													return true
+												})
+											}
+											cccItem.Children = append(cccItem.Children, ccccItem)
+											return true
+										})
+									}
+									ccItem.Children = append(ccItem.Children, cccItem)
+									return true
+								})
+							}
 							cItem.Children = append(cItem.Children, ccItem)
 							return true
 						})


### PR DESCRIPTION
## Summary

- Extend the `fromBody` code generation template from 3 to 6 levels of nested children parsing, fixing data loss during the GET→PUT round-trip in `update_ranks` resources
- Regenerate all affected model files

## Problem

The `update_ranks` resources (`ise_network_access_policy_set_update_ranks`, `ise_device_admin_policy_set_update_ranks`, and all authentication/authorization rule variants) perform a GET→modify rank→PUT round-trip. During the GET phase, `fromBody` deserializes the ISE API response into Go structs, but only parses **3 levels** of nested condition children.

When `toBody` re-serializes for the PUT, deeply nested `ConditionAndBlock`/`ConditionOrBlock` nodes at level 3+ are emitted without their children — ISE rejects these as invalid:

```
Failed to configure object (PUT), got error: HTTP Request failed: StatusCode 400,
Message: , {
  "message" : "condition.children[0].children[0].children[0].children, size must be between 1 and 2147483647",
  "code" : 400
}
```

This blocks any policy set, authentication rule, authorization rule, or authorization exception rule that uses conditions nested deeper than 3 levels from having its rank updated.

## Root Cause

The `fromBody` section of `gen/templates/model.go` only generates 3 levels of nested `ForEach` parsing loops, while:
- `toBody` already supports 6 levels
- The type definitions support 6 levels
- The YAML definitions define 6 levels of nesting

## Fix

Extend the `fromBody` template to generate parsing code for all 6 levels of nesting, matching `toBody`. Regenerate all model files.

## Test plan

- [x] `go build` passes
- [x] Integration tested against ISE 3.3 with 6-level deeply nested conditions on policy sets and rules — 162 resources created, full idempotency confirmed, clean destroy
- [ ] Provider acceptance tests pass

## Related

- Complements #202 (which extended YAML definitions and `toBody` to 6 levels)
- Complements #206 (sibling matching fix, already merged in v0.3.1)

---
### AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: template fix + code regeneration for fromBody depth parity
- **Human Oversight**: Code reviewed and integration tested by @ChristopherJHart