### PR TITLE
fix(internal_user): normalize empty custom_attributes {} to null

### DIFF
--- a/gen/definitions/internal_user.yaml
+++ b/gen/definitions/internal_user.yaml
@@ -71,6 +71,7 @@ attributes:
     data_path: [InternalUser]
     type: String
     description: Key value map
+    normalize_empty_json: true
     exclude_test: true
   - model_name: passwordIDStore
     data_path: [InternalUser]

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -143,8 +143,9 @@ type YamlConfigAttribute struct {
 	Mandatory        bool                  `yaml:"mandatory"`
 	Computed         bool                  `yaml:"computed"`
 	Immutable        bool                  `yaml:"immutable"`
-	WriteOnly        bool                  `yaml:"write_only"`
-	WriteChangesOnly bool                  `yaml:"write_changes_only"`
+	WriteOnly          bool                  `yaml:"write_only"`
+	NormalizeEmptyJson bool                  `yaml:"normalize_empty_json"`
+	WriteChangesOnly   bool                  `yaml:"write_changes_only"`
 	ExcludeUpdate    bool                  `yaml:"exclude_update"`
 	ExcludeTest      bool                  `yaml:"exclude_test"`
 	RequiresReplace  bool                  `yaml:"requires_replace"`

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -47,6 +47,7 @@ attribute:
   mandatory: bool(required=False) # Set to true if the attribute is mandatory
   computed: bool(required=False) # Set to true if the attribute is computed
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value
+  normalize_empty_json: bool(required=False) # Set to true to normalize an empty JSON object ({}) returned by the API to null, preventing drift when the config omits the attribute
   write_changes_only: bool(required=False) # Set to true if the attribute should only be written (included in PUT payload) if it has changed
   exclude_test: bool(required=False) # Exclude attribute from example (documentation) and acceptance test
   exclude_example: bool(required=False) # Exclude attribute from acceptance test only (example/documentation is still generated)

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -594,7 +594,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- $cname := toGoName .TfName}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && value.Type != gjson.Null{{if .NormalizeEmptyJson}} && value.Raw != "{}"{{end}} {
+	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && value.Type != gjson.Null{{if .NormalizeEmptyJson}} && !(value.Type == gjson.JSON && len(value.Map()) == 0){{end}} {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 	} else {
 		{{- if .DefaultValue}}
@@ -875,7 +875,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull(){{if .NormalizeEmptyJson}} && value.Raw != "{}"{{end}} {
+	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull(){{if .NormalizeEmptyJson}} && !(value.Type == gjson.JSON && len(value.Map()) == 0){{end}} {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 	} else {{if .DefaultValue}}if data.{{toGoName .TfName}}.Value{{.Type}}() != {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}} {{end}}{
 		data.{{toGoName .TfName}} = types.{{.Type}}Null()

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -594,7 +594,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- $cname := toGoName .TfName}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && value.Type != gjson.Null {
+	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && value.Type != gjson.Null{{if .NormalizeEmptyJson}} && value.Raw != "{}"{{end}} {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 	} else {
 		{{- if .DefaultValue}}
@@ -875,7 +875,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
-	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull() {
+	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull(){{if .NormalizeEmptyJson}} && value.Raw != "{}"{{end}} {
 		data.{{toGoName .TfName}} = types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}())
 	} else {{if .DefaultValue}}if data.{{toGoName .TfName}}.Value{{.Type}}() != {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}} {{end}}{
 		data.{{toGoName .TfName}} = types.{{.Type}}Null()

--- a/internal/provider/model_ise_internal_user.go
+++ b/internal/provider/model_ise_internal_user.go
@@ -159,7 +159,7 @@ func (data *InternalUser) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.IdentityGroups = types.StringNull()
 	}
-	if value := res.Get("InternalUser.customAttributes"); value.Exists() && value.Type != gjson.Null {
+	if value := res.Get("InternalUser.customAttributes"); value.Exists() && value.Type != gjson.Null && value.Raw != "{}" {
 		data.CustomAttributes = types.StringValue(value.String())
 	} else {
 		data.CustomAttributes = types.StringNull()
@@ -225,7 +225,7 @@ func (data *InternalUser) updateFromBody(ctx context.Context, res gjson.Result) 
 	} else {
 		data.IdentityGroups = types.StringNull()
 	}
-	if value := res.Get("InternalUser.customAttributes"); value.Exists() && !data.CustomAttributes.IsNull() {
+	if value := res.Get("InternalUser.customAttributes"); value.Exists() && !data.CustomAttributes.IsNull() && value.Raw != "{}" {
 		data.CustomAttributes = types.StringValue(value.String())
 	} else {
 		data.CustomAttributes = types.StringNull()

--- a/internal/provider/model_ise_internal_user.go
+++ b/internal/provider/model_ise_internal_user.go
@@ -159,7 +159,7 @@ func (data *InternalUser) fromBody(ctx context.Context, res gjson.Result) {
 	} else {
 		data.IdentityGroups = types.StringNull()
 	}
-	if value := res.Get("InternalUser.customAttributes"); value.Exists() && value.Type != gjson.Null && value.Raw != "{}" {
+	if value := res.Get("InternalUser.customAttributes"); value.Exists() && value.Type != gjson.Null && !(value.Type == gjson.JSON && len(value.Map()) == 0) {
 		data.CustomAttributes = types.StringValue(value.String())
 	} else {
 		data.CustomAttributes = types.StringNull()
@@ -225,7 +225,7 @@ func (data *InternalUser) updateFromBody(ctx context.Context, res gjson.Result) 
 	} else {
 		data.IdentityGroups = types.StringNull()
 	}
-	if value := res.Get("InternalUser.customAttributes"); value.Exists() && !data.CustomAttributes.IsNull() && value.Raw != "{}" {
+	if value := res.Get("InternalUser.customAttributes"); value.Exists() && !data.CustomAttributes.IsNull() && !(value.Type == gjson.JSON && len(value.Map()) == 0) {
 		data.CustomAttributes = types.StringValue(value.String())
 	} else {
 		data.CustomAttributes = types.StringNull()


### PR DESCRIPTION
## Summary

Fixes #227

**Root cause:** ISE returns `customAttributes: { }` (space between braces) for users with no custom attributes. The provider stored this as the non-null string `"{ }"` in state. When config omits `custom_attributes`, Terraform plans `custom_attributes = jsonencode({}) -> null` on every cycle.

The initial fix used `value.Raw != "{}"` (exact string match), which correctly handled `{}` but missed `{ }` — the actual format ISE returns. Any whitespace variant of an empty JSON object was not caught.

**Fix:** Replace the string comparison with `!(value.Type == gjson.JSON && len(value.Map()) == 0)`, which identifies any empty JSON object regardless of internal whitespace by checking the parsed map length rather than the raw bytes.

**Verified:** Confirmed against a live ISE instance — no `custom_attributes` drift after the fix.

## Changes

- `gen/templates/model.go` — replace `value.Raw != "{}"` with `!(value.Type == gjson.JSON && len(value.Map()) == 0)` in `fromBody` and `updateFromBody` when `normalize_empty_json` is set
- `gen/definitions/internal_user.yaml` — set `normalize_empty_json: true` on `customAttributes`
- `gen/generator.go` — add `NormalizeEmptyJson bool` field to the attribute struct
- `gen/schema/schema.yaml` — document the new `normalize_empty_json` definition flag
- `internal/provider/model_ise_internal_user.go` — regenerated

## Test plan

`go test ./...` — all pass.

Verified against live ISE node: `terraform plan` shows no `custom_attributes` change for users without custom attributes after fix.

Before fix:
```
~ resource "ise_internal_user" "internal_user" {
  - custom_attributes = jsonencode({})
    name              = "someuser"
}
```

After fix — no change planned for users without custom attributes.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause investigation, live ISE testing, and fix
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae