### PR TITLE
fix(provider): mark empty-string optional fields as Computed to prevent drift

### DIFF
--- a/gen/definitions/active_directory_join_point.yaml
+++ b/gen/definitions/active_directory_join_point.yaml
@@ -160,7 +160,7 @@ attributes:
     data_path: [ERSActiveDirectory, advancedSettings]
     type: Int64
     requires_replace: true
-    default_value: 5
+    computed: true
     description: Aging Time
     example: 5
   - model_name: enableCallbackForDialinClient

--- a/gen/definitions/active_directory_join_point.yaml
+++ b/gen/definitions/active_directory_join_point.yaml
@@ -16,6 +16,7 @@ attributes:
     type: String
     requires_replace: true
     description: Join point description
+    computed: true
     example: My AD join point
   - model_name: domain
     data_path: [ERSActiveDirectory]

--- a/gen/definitions/authorization_profile.yaml
+++ b/gen/definitions/authorization_profile.yaml
@@ -16,6 +16,7 @@ attributes:
     data_path: [AuthorizationProfile]
     type: String
     description: Description
+    computed: true
     example: My Authorization Profile
   - model_name: nameID
     data_path: [AuthorizationProfile, vlan]
@@ -48,6 +49,7 @@ attributes:
     tf_name: web_redirection_acl
     type: String
     description: Web redirection ACL
+    computed: true
     example: TEST_ACL
   - model_name: portalName
     data_path: [AuthorizationProfile, webRedirection]

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -22,6 +22,7 @@ attributes:
     tf_name: authentication_enable_key_wrap
     type: Bool
     description: Enable key wrap
+    computed: true
     example: true
   - model_name: keyEncryptionKey
     data_path: [NetworkDevice, authenticationSettings]
@@ -36,6 +37,7 @@ attributes:
     type: String
     enum_values: [ASCII, HEXADECIMAL]
     description: Key input format
+    computed: true
     example: ASCII
   - model_name: messageAuthenticatorCodeKey
     data_path: [NetworkDevice, authenticationSettings]
@@ -62,6 +64,7 @@ attributes:
     tf_name: authentication_enable_multi_secret
     type: Bool
     description: Enable multiple RADIUS shared secrets
+    computed: true
     example: true
   - model_name: secondRadiusSharedSecret
     data_path: [NetworkDevice, authenticationSettings]
@@ -74,6 +77,7 @@ attributes:
     tf_name: authentication_dtls_required
     type: Bool
     description: Enforce use of DTLS
+    computed: true
     example: true
   - model_name: coaPort
     data_path: [NetworkDevice]

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -15,6 +15,7 @@ attributes:
     data_path: [NetworkDevice]
     type: String
     description: Description
+    computed: true
     example: My device
   - model_name: enableKeyWrap
     data_path: [NetworkDevice, authenticationSettings]
@@ -27,6 +28,7 @@ attributes:
     tf_name: authentication_encryption_key
     type: String
     description: Encryption key
+    computed: true
     example: cisco123cisco123
   - model_name: keyInputFormat
     data_path: [NetworkDevice, authenticationSettings]
@@ -40,6 +42,7 @@ attributes:
     tf_name: authentication_message_authenticator_code_key
     type: String
     description: Message authenticator code key
+    computed: true
     example: cisco123cisco1235678
   - model_name: networkProtocol
     data_path: [NetworkDevice, authenticationSettings]

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -148,14 +148,14 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 				{{- else if and .DefaultValue (eq .Type "String")}}
 				Default:             stringdefault.StaticString("{{.DefaultValue}}"),
 				{{- end}}
-				{{- if or .Id .Reference .RequiresReplace}}
+				{{- if or .Id .Reference .RequiresReplace .Computed}}
 				PlanModifiers: []planmodifier.{{.Type}}{
+					{{- if or .Id .Reference .RequiresReplace}}
 					{{snakeCase .Type}}planmodifier.RequiresReplace(),
-				},
-				{{- end}}
-				{{- if .Computed}}
-				PlanModifiers: []planmodifier.{{.Type}}{
+					{{- end}}
+					{{- if .Computed}}
 					{{snakeCase .Type}}planmodifier.UseStateForUnknown(),
+					{{- end}}
 				},
 				{{- end}}
 				{{- if isNestedListSet .}}
@@ -220,14 +220,14 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 							{{- else if and .DefaultValue (eq .Type "String")}}
 							Default:             stringdefault.StaticString("{{.DefaultValue}}"),
 							{{- end}}
-							{{- if .RequiresReplace}}
+							{{- if or .RequiresReplace .Computed}}
 							PlanModifiers: []planmodifier.{{.Type}}{
+								{{- if .RequiresReplace}}
 								{{snakeCase .Type}}planmodifier.RequiresReplace(),
-							},
-							{{- end}}
-							{{- if .Computed}}
-							PlanModifiers: []planmodifier.{{.Type}}{
+								{{- end}}
+								{{- if .Computed}}
 								{{snakeCase .Type}}planmodifier.UseStateForUnknown(),
+								{{- end}}
 							},
 							{{- end}}
 							{{- if isNestedListSet .}}

--- a/internal/provider/model_ise_active_directory_join_point.go
+++ b/internal/provider/model_ise_active_directory_join_point.go
@@ -378,7 +378,7 @@ func (data *ActiveDirectoryJoinPoint) fromBody(ctx context.Context, res gjson.Re
 	if value := res.Get("ERSActiveDirectory.advancedSettings.agingTime"); value.Exists() && value.Type != gjson.Null {
 		data.AgingTime = types.Int64Value(value.Int())
 	} else {
-		data.AgingTime = types.Int64Value(5)
+		data.AgingTime = types.Int64Null()
 	}
 	if value := res.Get("ERSActiveDirectory.advancedSettings.enableCallbackForDialinClient"); value.Exists() && value.Type != gjson.Null {
 		data.EnableCallbackForDialinClient = types.BoolValue(value.Bool())
@@ -668,7 +668,7 @@ func (data *ActiveDirectoryJoinPoint) updateFromBody(ctx context.Context, res gj
 	}
 	if value := res.Get("ERSActiveDirectory.advancedSettings.agingTime"); value.Exists() && !data.AgingTime.IsNull() {
 		data.AgingTime = types.Int64Value(value.Int())
-	} else if data.AgingTime.ValueInt64() != 5 {
+	} else {
 		data.AgingTime = types.Int64Null()
 	}
 	if value := res.Get("ERSActiveDirectory.advancedSettings.enableCallbackForDialinClient"); value.Exists() && !data.EnableCallbackForDialinClient.IsNull() {

--- a/internal/provider/resource_ise_active_directory_join_point.go
+++ b/internal/provider/resource_ise_active_directory_join_point.go
@@ -270,12 +270,12 @@ func (r *ActiveDirectoryJoinPointResource) Schema(ctx context.Context, req resou
 				},
 			},
 			"aging_time": schema.Int64Attribute{
-				MarkdownDescription: helpers.NewAttributeDescription("Aging Time").AddDefaultValueDescription("5").String,
+				MarkdownDescription: helpers.NewAttributeDescription("Aging Time").String,
 				Optional:            true,
 				Computed:            true,
-				Default:             int64default.StaticInt64(5),
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"enable_callback_for_dialin_client": schema.BoolAttribute{

--- a/internal/provider/resource_ise_active_directory_join_point.go
+++ b/internal/provider/resource_ise_active_directory_join_point.go
@@ -87,8 +87,10 @@ func (r *ActiveDirectoryJoinPointResource) Schema(ctx context.Context, req resou
 			"description": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Join point description").String,
 				Optional:            true,
+				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"domain": schema.StringAttribute{

--- a/internal/provider/resource_ise_authorization_profile.go
+++ b/internal/provider/resource_ise_authorization_profile.go
@@ -85,6 +85,10 @@ func (r *AuthorizationProfileResource) Schema(ctx context.Context, req resource.
 			"description": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Description").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"vlan_name_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Vlan name or ID").String,
@@ -107,6 +111,10 @@ func (r *AuthorizationProfileResource) Schema(ctx context.Context, req resource.
 			"web_redirection_acl": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Web redirection ACL").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"web_redirection_portal_name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("A portal that exist in the DB and fits the `web_redirection_type`").String,

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -93,6 +94,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_enable_key_wrap": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enable key wrap").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"authentication_encryption_key": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Encryption key").String,
@@ -105,8 +110,12 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_encryption_key_format": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Key input format").AddStringEnumDescription("ASCII", "HEXADECIMAL").String,
 				Optional:            true,
+				Computed:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("ASCII", "HEXADECIMAL"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"authentication_message_authenticator_code_key": schema.StringAttribute{
@@ -131,6 +140,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_enable_multi_secret": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enable multiple RADIUS shared secrets").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"authentication_second_radius_shared_secret": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Second RADIUS shared secret").String,
@@ -139,6 +152,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_dtls_required": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enforce use of DTLS").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"coa_port": schema.Int64Attribute{
 				MarkdownDescription: helpers.NewAttributeDescription("CoA port").AddDefaultValueDescription("1700").String,

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -85,6 +85,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"description": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Description").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"authentication_enable_key_wrap": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enable key wrap").String,
@@ -93,6 +97,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_encryption_key": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Encryption key").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"authentication_encryption_key_format": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Key input format").AddStringEnumDescription("ASCII", "HEXADECIMAL").String,
@@ -104,6 +112,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 			"authentication_message_authenticator_code_key": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Message authenticator code key").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"authentication_network_protocol": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Network protocol").AddStringEnumDescription("RADIUS", "TACACS_PLUS").String,


### PR DESCRIPTION
## Summary

Fixes #230

**Root cause:** Optional string and boolean fields that ISE returns as empty string `""` or default boolean/string values (`false`, `"ASCII"`) were not declared as `Computed` in the provider schema. When config is null and state has these values, Terraform plans to change them to null. For `ise_active_directory_join_point.description` which has `requires_replace`, this forces a full resource replacement. For TACACS-only network devices where RADIUS authentication is not configured, ISE returns default values that persist in state causing drift on every plan.

**Fix:** Add `computed: true` to the affected fields. With `Optional + Computed`, Terraform preserves the prior state value when config is null.

Also removes `default_value: 5` from `aging_time` on `ise_active_directory_join_point` and adds `computed: true` — see commit message for full reasoning.

## Changes

**Empty-string fields (original fix):**
- `gen/definitions/authorization_profile.yaml` — `description`, `web_redirection_acl`: add `computed: true`
- `gen/definitions/network_device.yaml` — `description`, `authentication_encryption_key`, `authentication_message_authenticator_code_key`: add `computed: true`
- `gen/definitions/active_directory_join_point.yaml` — `description`: add `computed: true`
- `gen/templates/resource.go` — merge `RequiresReplace` and `UseStateForUnknown` into one `PlanModifiers` block

**aging_time fix:**
- `gen/definitions/active_directory_join_point.yaml` — remove `default_value: 5`, add `computed: true`

**RADIUS default fields (TACACS-only devices):**
- `gen/definitions/network_device.yaml` — `authentication_enable_key_wrap`, `authentication_encryption_key_format`, `authentication_enable_multi_secret`, `authentication_dtls_required`: add `computed: true`

**Regenerated:**
- `internal/provider/resource_ise_authorization_profile.go`
- `internal/provider/resource_ise_network_device.go`
- `internal/provider/resource_ise_active_directory_join_point.go`

## Test plan

`go test ./...` — all pass.

Before fix (authorization profile): `- web_redirection_acl = "" -> null` on every plan
Before fix (AD join point): `must be replaced` due to `description = "" -> null`
Before fix (network device): `- authentication_dtls_required = false -> null`, `- authentication_encryption_key_format = "ASCII" -> null`

After fix: all stable — no changes planned for any of the above.

Verified against live ISE node.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, live ISE testing, and fixes
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae