### PR TITLE
fix(endpoint): preserve custom_attributes and group_id on brownfield import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.5 (unreleased)
+
+- Fix brownfield import drift on `ise_endpoint.custom_attributes` by using `GetStringMapFiltered` in import read (`fromBody`) when `filter_empty_values` is set, matching `updateFromBody` behavior
+- Mark `group_id` as computed on `ise_endpoint` so imported group membership is preserved when omitted from config with `static_group_assignment = false`
+
 ## 0.3.4
 
 - Fix perpetual drift in the `custom_attributes` attribute of the `ise_endpoint` resource, where ISE returns all globally-defined endpoint custom attributes (including unassigned ones as empty strings), causing Terraform to report changes on every plan

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## 0.3.5 (unreleased)
+
+- Fix brownfield import drift on `ise_endpoint.custom_attributes` by using `GetStringMapFiltered` in import read (`fromBody`) when `filter_empty_values` is set, matching `updateFromBody` behavior
+- Mark `group_id` as computed on `ise_endpoint` so imported group membership is preserved when omitted from config with `static_group_assignment = false`
+
 ## 0.3.4
 
 - Fix perpetual drift in the `custom_attributes` attribute of the `ise_endpoint` resource, where ISE returns all globally-defined endpoint custom attributes (including unassigned ones as empty strings), causing Terraform to report changes on every plan

--- a/gen/definitions/endpoint.yaml
+++ b/gen/definitions/endpoint.yaml
@@ -26,6 +26,7 @@ attributes:
     data_path: [ERSEndPoint]
     type: String
     description: Identity Group ID
+    computed: true
     example: 3a88eec0-8c00-11e6-996c-525400b48521
     test_value: ise_endpoint_identity_group.test.id
   - model_name: profileId

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -70,4 +70,4 @@ attribute:
   minimum_test_value: str(required=False) # Value used for "minimum" resource acceptance test
   test_tags: list(str(), required=False) # List of test tags, attribute is only included in acceptance tests if an environment variable with one of these tags is configured
   attributes: list(include('attribute'), required=False) # List of attributes, only relevant if type is "List" or "Set"
-  filter_empty_values: bool(required=False) # Set to true to drop empty-string values when reading a Map attribute from the API response (e.g. ISE endpoint custom attributes where "" means unset)
+  filter_empty_values: bool(required=False) # Drop empty-string map values on read when config omits the attribute; when config declares keys (even as ""), preserve those keys via GetStringMapFiltered (e.g. ISE endpoint custom attributes)

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -612,7 +612,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	{{- else if eq .Type "Map"}}
 	if value := res.Get("{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}"); value.Exists() {
 		{{- if .FilterEmptyValues}}
-		data.{{toGoName .TfName}} = helpers.GetStringMapNonEmpty(value.Map())
+		data.{{toGoName .TfName}} = helpers.GetStringMapFiltered(value.Map(), data.{{toGoName .TfName}})
 		{{- else}}
 		data.{{toGoName .TfName}} = helpers.GetStringMap(value.Map())
 		{{- end}}

--- a/internal/provider/helpers/utils_test.go
+++ b/internal/provider/helpers/utils_test.go
@@ -1,0 +1,45 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/tidwall/gjson"
+)
+
+func TestGetStringMapFilteredPreservesConfigKeysWithEmptyAPIValues(t *testing.T) {
+	t.Parallel()
+
+	apiResult := map[string]gjson.Result{
+		"RequiresRoutableAddress": gjson.Parse(`""`),
+		"InjectedByISE":           gjson.Parse(`""`),
+	}
+	configMap := types.MapValueMust(types.StringType, map[string]attr.Value{
+		"RequiresRoutableAddress": types.StringValue(""),
+	})
+
+	m := GetStringMapFiltered(apiResult, configMap)
+	elements := m.Elements()
+	if len(elements) != 1 {
+		t.Fatalf("expected 1 config key preserved, got %d", len(elements))
+	}
+	if v, ok := elements["RequiresRoutableAddress"]; !ok {
+		t.Fatalf("expected RequiresRoutableAddress key preserved, got %#v", elements)
+	} else if sv, ok := v.(types.String); !ok || sv.ValueString() != "" {
+		t.Fatalf("expected empty string preserved for declared config key, got %#v", v)
+	}
+}
+
+func TestGetStringMapFilteredImportUsesAllAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	apiResult := map[string]gjson.Result{
+		"RequiresRoutableAddress": gjson.Parse(`""`),
+	}
+	m := GetStringMapFiltered(apiResult, types.MapNull(types.StringType))
+	elements := m.Elements()
+	if len(elements) != 1 {
+		t.Fatalf("expected all API keys when config is null, got %d", len(elements))
+	}
+}

--- a/internal/provider/model_ise_endpoint.go
+++ b/internal/provider/model_ise_endpoint.go
@@ -211,7 +211,7 @@ func (data *Endpoint) fromBody(ctx context.Context, res gjson.Result) {
 		data.StaticGroupAssignmentDefined = types.BoolValue(true)
 	}
 	if value := res.Get("ERSEndPoint.customAttributes.customAttributes"); value.Exists() {
-		data.CustomAttributes = helpers.GetStringMapNonEmpty(value.Map())
+		data.CustomAttributes = helpers.GetStringMapFiltered(value.Map(), data.CustomAttributes)
 	} else {
 		data.CustomAttributes = types.MapNull(types.StringType)
 	}

--- a/internal/provider/resource_ise_endpoint.go
+++ b/internal/provider/resource_ise_endpoint.go
@@ -204,6 +204,24 @@ func (r *EndpointResource) Configure(_ context.Context, req resource.ConfigureRe
 
 //template:end configure
 
+func (r *EndpointResource) refreshPlanFromAPI(ctx context.Context, plan *Endpoint, resp *resource.CreateResponse) bool {
+	res, err := r.client.Get(plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString()))
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to retrieve object after create (GET), got error: %s, %s", err, res.String()))
+		return false
+	}
+	if plan.GroupId.IsUnknown() {
+		if value := res.Get("ERSEndPoint.groupId"); value.Exists() {
+			plan.GroupId = types.StringValue(value.String())
+		} else {
+			plan.GroupId = types.StringNull()
+		}
+	} else {
+		plan.updateFromBody(ctx, res)
+	}
+	return true
+}
+
 func (r *EndpointResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan Endpoint
 
@@ -225,6 +243,10 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
+		if !r.refreshPlanFromAPI(ctx, &plan, resp) {
+			return
+		}
+
 		diags = resp.State.Set(ctx, &plan)
 		resp.Diagnostics.Append(diags...)
 		return
@@ -245,6 +267,10 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 		}
 
 		tflog.Debug(ctx, fmt.Sprintf("%s: Update finished successfully", plan.Id.ValueString()))
+
+		if !r.refreshPlanFromAPI(ctx, &plan, resp) {
+			return
+		}
 
 		diags = resp.State.Set(ctx, &plan)
 		resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_ise_endpoint.go
+++ b/internal/provider/resource_ise_endpoint.go
@@ -89,6 +89,10 @@ func (r *EndpointResource) Schema(ctx context.Context, req resource.SchemaReques
 			"group_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Identity Group ID").String,
 				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"profile_id": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Profile ID").String,

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,11 @@ description: |-
 
 # Changelog
 
+## 0.3.5 (unreleased)
+
+- Fix brownfield import drift on `ise_endpoint.custom_attributes` by using `GetStringMapFiltered` in import read (`fromBody`) when `filter_empty_values` is set, matching `updateFromBody` behavior
+- Mark `group_id` as computed on `ise_endpoint` so imported group membership is preserved when omitted from config with `static_group_assignment = false`
+
 ## 0.3.4
 
 - Fix perpetual drift in the `custom_attributes` attribute of the `ise_endpoint` resource, where ISE returns all globally-defined endpoint custom attributes (including unassigned ones as empty strings), causing Terraform to report changes on every plan


### PR DESCRIPTION
## Summary

Fixes #241

**Root cause:** `filter_empty_values` maps used `GetStringMapFiltered` in `updateFromBody` but `GetStringMapNonEmpty` in `fromBody`. On import (state map still null), empty-string API values for declared custom attribute keys were dropped, causing `null → ""` drift at scale. Separately, `group_id` was optional but not computed, so omitting it when `static_group_assignment = false` planned `uuid → null` updates.

**Impact:** Large numbers of phantom `ise_endpoint` plan updates after brownfield import.

**Fix:**
- Use `GetStringMapFiltered` in `fromBody` for `filter_empty_values` maps (generator template change).
- Mark `group_id` as `computed: true` with `UseStateForUnknown` in the endpoint definition.
- After Create (POST or update-on-exists PUT), GET the endpoint and populate `group_id` when it is unknown in plan so apply completes with known state.

## Changes

- `gen/templates/model.go` — `fromBody` uses `GetStringMapFiltered` when `filter_empty_values` is set
- `gen/definitions/endpoint.yaml` — `group_id` marked computed
- `gen/schema/schema.yaml` — clarify `filter_empty_values` documentation
- `internal/provider/model_ise_endpoint.go` — regenerated
- `internal/provider/resource_ise_endpoint.go` — regenerated (`group_id` computed + plan modifier); manual Create refresh for computed `group_id`
- `internal/provider/helpers/utils_test.go` — unit tests for import/config filtering behavior
- `CHANGELOG.md`, `templates/guides/changelog.md.tmpl`, `docs/guides/changelog.md` — unreleased entry

## Test plan

```bash
yamale -s gen/schema/schema.yaml gen/definitions/
go generate ./...
git diff --exit-code
go build -v .
go test ./...
```

```
=== RUN   TestGetStringMapFilteredPreservesConfigKeysWithEmptyAPIValues
--- PASS: TestGetStringMapFilteredPreservesConfigKeysWithEmptyAPIValues (0.00s)
=== RUN   TestGetStringMapFilteredImportUsesAllAPIKeys
--- PASS: TestGetStringMapFilteredImportUsesAllAPIKeys (0.00s)
PASS
ok  	github.com/CiscoDevNet/terraform-provider-ise/internal/provider/helpers	0.002s
ok  	github.com/CiscoDevNet/terraform-provider-ise/internal/provider	0.015s
```

Acceptance test (`TF_ACC=1`, live ISE lab):

```bash
go test ./internal/provider/ -v -count=1 -timeout 30m -run '^TestAccIseEndpoint$'
```

```
=== RUN   TestAccIseEndpoint
--- PASS: TestAccIseEndpoint (6.08s)
PASS
ok  	github.com/CiscoDevNet/terraform-provider-ise/internal/provider	6.089s
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Brownfield import drift investigation and generator/template fix
- **Human Oversight**: Code reviewed and approved by camschae

Made with [Cursor](https://cursor.com)