### PR TITLE
add computed when flag on endpoint

### DIFF
--- a/gen/definitions/endpoint.yaml
+++ b/gen/definitions/endpoint.yaml
@@ -33,6 +33,7 @@ attributes:
     type: String
     description: Profile ID
     computed: true
+    computed_when: static_profile_assignment=false
     example: 3a91a150-8c00-11e6-996c-525400b48521
   - model_name: staticProfileAssignment
     data_path: [ERSEndPoint]

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -142,6 +142,7 @@ type YamlConfigAttribute struct {
 	ResponseDataPath string                `yaml:"response_data_path"`
 	Mandatory        bool                  `yaml:"mandatory"`
 	Computed         bool                  `yaml:"computed"`
+	ComputedWhen     string                `yaml:"computed_when"`
 	Immutable        bool                  `yaml:"immutable"`
 	WriteOnly        bool                  `yaml:"write_only"`
 	WriteChangesOnly bool                  `yaml:"write_changes_only"`
@@ -241,6 +242,24 @@ func HasId(attributes []YamlConfigAttribute) bool {
 		}
 	}
 	return false
+}
+
+// ComputedWhenAttr returns the sibling attribute name from a computed_when
+// expression of the form "<attr>=<bool>" (e.g. "static_profile_assignment=false"
+// -> "static_profile_assignment").
+func ComputedWhenAttr(expr string) string {
+	parts := strings.SplitN(expr, "=", 2)
+	return strings.TrimSpace(parts[0])
+}
+
+// ComputedWhenValue returns the boolean literal ("true"/"false") from a
+// computed_when expression. Defaults to "false" if omitted.
+func ComputedWhenValue(expr string) string {
+	parts := strings.SplitN(expr, "=", 2)
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		return "false"
+	}
+	return strings.TrimSpace(parts[1])
 }
 
 // Templating helper function to return true if reference included in attributes
@@ -371,6 +390,8 @@ var functions = template.FuncMap{
 	"path":                   BuildPath,
 	"hasId":                  HasId,
 	"getId":                  GetId,
+	"computedWhenAttr":       ComputedWhenAttr,
+	"computedWhenValue":      ComputedWhenValue,
 	"hasReference":           HasReference,
 	"importParts":            ImportParts,
 	"subtract":               Subtract,

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -244,16 +244,13 @@ func HasId(attributes []YamlConfigAttribute) bool {
 	return false
 }
 
-// ComputedWhenAttr returns the sibling attribute name from a computed_when
-// expression of the form "<attr>=<bool>" (e.g. "static_profile_assignment=false"
-// -> "static_profile_assignment").
+// ComputedWhenAttr returns the attribute name from a "<attr>=<bool>" expression.
 func ComputedWhenAttr(expr string) string {
 	parts := strings.SplitN(expr, "=", 2)
 	return strings.TrimSpace(parts[0])
 }
 
-// ComputedWhenValue returns the boolean literal ("true"/"false") from a
-// computed_when expression. Defaults to "false" if omitted.
+// ComputedWhenValue returns the bool literal from a "<attr>=<bool>" expression (default "false").
 func ComputedWhenValue(expr string) string {
 	parts := strings.SplitN(expr, "=", 2)
 	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -46,7 +46,7 @@ attribute:
   data_source_query: bool(required=False) # Set to true if the attribute is an alternative query parameter for the data source
   mandatory: bool(required=False) # Set to true if the attribute is mandatory
   computed: bool(required=False) # Set to true if the attribute is computed
-  computed_when: str(required=False) # Conditional computed marker "<sibling_bool_attr>=<true|false>". When the sibling Bool equals the given value and this attribute is unset in config, keep the prior state value instead of planning a change to null (conditional alternative to UseStateForUnknown for conditionally server-owned fields, e.g. "static_profile_assignment=false")
+  computed_when: str(required=False) # Conditional computed marker "<bool_attr>=<true|false>"; when the sibling Bool matches and this attribute is unset in config, keep the prior state value (conditional UseStateForUnknown, e.g. "static_profile_assignment=false")
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value
   write_changes_only: bool(required=False) # Set to true if the attribute should only be written (included in PUT payload) if it has changed
   exclude_test: bool(required=False) # Exclude attribute from example (documentation) and acceptance test

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -46,6 +46,7 @@ attribute:
   data_source_query: bool(required=False) # Set to true if the attribute is an alternative query parameter for the data source
   mandatory: bool(required=False) # Set to true if the attribute is mandatory
   computed: bool(required=False) # Set to true if the attribute is computed
+  computed_when: str(required=False) # Conditional computed marker "<sibling_bool_attr>=<true|false>". When the sibling Bool equals the given value and this attribute is unset in config, keep the prior state value instead of planning a change to null (conditional alternative to UseStateForUnknown for conditionally server-owned fields, e.g. "static_profile_assignment=false")
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value
   write_changes_only: bool(required=False) # Set to true if the attribute should only be written (included in PUT payload) if it has changed
   exclude_test: bool(required=False) # Exclude attribute from example (documentation) and acceptance test

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -156,7 +156,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 				{{- if .Computed}}
 				PlanModifiers: []planmodifier.{{.Type}}{
 					{{- if .ComputedWhen}}
-					helpers.AdoptStateWhenSiblingBoolEquals("{{computedWhenAttr .ComputedWhen}}", {{computedWhenValue .ComputedWhen}}),
+					helpers.ComputedWhen("{{computedWhenAttr .ComputedWhen}}", {{computedWhenValue .ComputedWhen}}),
 					{{- else}}
 					{{snakeCase .Type}}planmodifier.UseStateForUnknown(),
 					{{- end}}

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -155,7 +155,11 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 				{{- end}}
 				{{- if .Computed}}
 				PlanModifiers: []planmodifier.{{.Type}}{
+					{{- if .ComputedWhen}}
+					helpers.AdoptStateWhenSiblingBoolEquals("{{computedWhenAttr .ComputedWhen}}", {{computedWhenValue .ComputedWhen}}),
+					{{- else}}
 					{{snakeCase .Type}}planmodifier.UseStateForUnknown(),
+					{{- end}}
 				},
 				{{- end}}
 				{{- if isNestedListSet .}}

--- a/internal/provider/helpers/plan_modifiers.go
+++ b/internal/provider/helpers/plan_modifiers.go
@@ -1,0 +1,88 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Mozilla Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://mozilla.org/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// AdoptStateWhenSiblingBoolEquals returns a String plan modifier for an attribute
+// whose ownership flips based on a sibling Bool attribute. It backs the definition
+// flag `computed_when: <sibling>=<bool>`.
+//
+//   - sibling != expected → the attribute is operator-owned; the modifier does nothing
+//     and the normal config-vs-state diff applies.
+//   - sibling == expected → the attribute is server-owned (ISE computes it). When the
+//     operator leaves the attribute unset (config null), the modifier keeps the prior
+//     state value instead of planning a change to null. This is what prevents the
+//     perpetual "UUID -> null" ghost diff on ise_endpoint.profile_id for dynamically
+//     profiled endpoints (static_profile_assignment=false) after a brownfield import.
+//
+// Unlike UseStateForUnknown, this only suppresses the diff on the server-owned branch,
+// so genuine operator changes on the operator-owned branch still plan normally, and
+// the attribute is not blanket-frozen.
+func AdoptStateWhenSiblingBoolEquals(siblingAttr string, expected bool) planmodifier.String {
+	return adoptStateWhenSiblingBoolEquals{siblingAttr: siblingAttr, expected: expected}
+}
+
+type adoptStateWhenSiblingBoolEquals struct {
+	siblingAttr string
+	expected    bool
+}
+
+func (m adoptStateWhenSiblingBoolEquals) Description(_ context.Context) string {
+	return fmt.Sprintf("Keeps the prior state value when the sibling attribute '%s' is %t "+
+		"and this attribute is not set in the configuration.", m.siblingAttr, m.expected)
+}
+
+func (m adoptStateWhenSiblingBoolEquals) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m adoptStateWhenSiblingBoolEquals) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Only act when the operator did not set this attribute in the configuration.
+	// An explicit config value (including an explicit null) is always honored.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	// On create there is no prior state to adopt; leave the planned value as-is.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Read the sibling Bool from the plan. If it is unknown or does not match the
+	// expected value, do nothing (operator-owned branch).
+	var sibling types.Bool
+	diags := req.Plan.GetAttribute(ctx, path.Root(m.siblingAttr), &sibling)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if sibling.IsUnknown() || sibling.IsNull() || sibling.ValueBool() != m.expected {
+		return
+	}
+
+	// Server-owned branch (sibling == expected) with no operator config: keep state.
+	resp.PlanValue = req.StateValue
+}

--- a/internal/provider/helpers/plan_modifiers.go
+++ b/internal/provider/helpers/plan_modifiers.go
@@ -26,53 +26,38 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// AdoptStateWhenSiblingBoolEquals returns a String plan modifier for an attribute
-// whose ownership flips based on a sibling Bool attribute. It backs the definition
-// flag `computed_when: <sibling>=<bool>`.
-//
-//   - sibling != expected → the attribute is operator-owned; the modifier does nothing
-//     and the normal config-vs-state diff applies.
-//   - sibling == expected → the attribute is server-owned (ISE computes it). When the
-//     operator leaves the attribute unset (config null), the modifier keeps the prior
-//     state value instead of planning a change to null. This is what prevents the
-//     perpetual "UUID -> null" ghost diff on ise_endpoint.profile_id for dynamically
-//     profiled endpoints (static_profile_assignment=false) after a brownfield import.
-//
-// Unlike UseStateForUnknown, this only suppresses the diff on the server-owned branch,
-// so genuine operator changes on the operator-owned branch still plan normally, and
-// the attribute is not blanket-frozen.
-func AdoptStateWhenSiblingBoolEquals(siblingAttr string, expected bool) planmodifier.String {
-	return adoptStateWhenSiblingBoolEquals{siblingAttr: siblingAttr, expected: expected}
+// ComputedWhen returns a String plan modifier backing the definition flag
+// `computed_when: <sibling>=<bool>`. When the sibling Bool equals expected and the
+// attribute is unset in config, it keeps the prior state value instead of planning a
+// change to null (a conditional UseStateForUnknown for server-owned-on-condition fields).
+func ComputedWhen(siblingAttr string, expected bool) planmodifier.String {
+	return computedWhen{siblingAttr: siblingAttr, expected: expected}
 }
 
-type adoptStateWhenSiblingBoolEquals struct {
+type computedWhen struct {
 	siblingAttr string
 	expected    bool
 }
 
-func (m adoptStateWhenSiblingBoolEquals) Description(_ context.Context) string {
+func (m computedWhen) Description(_ context.Context) string {
 	return fmt.Sprintf("Keeps the prior state value when the sibling attribute '%s' is %t "+
 		"and this attribute is not set in the configuration.", m.siblingAttr, m.expected)
 }
 
-func (m adoptStateWhenSiblingBoolEquals) MarkdownDescription(ctx context.Context) string {
+func (m computedWhen) MarkdownDescription(ctx context.Context) string {
 	return m.Description(ctx)
 }
 
-func (m adoptStateWhenSiblingBoolEquals) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Only act when the operator did not set this attribute in the configuration.
-	// An explicit config value (including an explicit null) is always honored.
+func (m computedWhen) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// An explicit config value (including explicit null) is always honored.
 	if !req.ConfigValue.IsNull() {
 		return
 	}
-
-	// On create there is no prior state to adopt; leave the planned value as-is.
+	// On create there is no prior state to adopt.
 	if req.StateValue.IsNull() {
 		return
 	}
-
-	// Read the sibling Bool from the plan. If it is unknown or does not match the
-	// expected value, do nothing (operator-owned branch).
+	// Keep state only on the server-owned branch (sibling == expected).
 	var sibling types.Bool
 	diags := req.Plan.GetAttribute(ctx, path.Root(m.siblingAttr), &sibling)
 	resp.Diagnostics.Append(diags...)
@@ -82,7 +67,5 @@ func (m adoptStateWhenSiblingBoolEquals) PlanModifyString(ctx context.Context, r
 	if sibling.IsUnknown() || sibling.IsNull() || sibling.ValueBool() != m.expected {
 		return
 	}
-
-	// Server-owned branch (sibling == expected) with no operator config: keep state.
 	resp.PlanValue = req.StateValue
 }

--- a/internal/provider/resource_ise_endpoint.go
+++ b/internal/provider/resource_ise_endpoint.go
@@ -95,7 +95,7 @@ func (r *EndpointResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					helpers.AdoptStateWhenSiblingBoolEquals("static_profile_assignment", false),
 				},
 			},
 			"static_profile_assignment": schema.BoolAttribute{
@@ -223,6 +223,20 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 		locationElements := strings.Split(location, "/")
 		plan.Id = types.StringValue(locationElements[len(locationElements)-1])
 
+		// profile_id is Optional+Computed: ISE assigns it (empty for dynamic endpoints
+		// until the profiler runs). Read the created object back so the Computed value
+		// is known after apply, as the framework requires.
+		res, err := r.client.Get(plan.getPath() + "/" + url.QueryEscape(plan.Id.ValueString()))
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Failed to read back created object (GET), got error: %s, %s", err, res.String()))
+			return
+		}
+		if value := res.Get("ERSEndPoint.profileId"); value.Exists() && value.String() != "" {
+			plan.ProfileId = types.StringValue(value.String())
+		} else {
+			plan.ProfileId = types.StringNull()
+		}
+
 		tflog.Debug(ctx, fmt.Sprintf("%s: Create finished successfully", plan.Id.ValueString()))
 
 		diags = resp.State.Set(ctx, &plan)
@@ -235,6 +249,13 @@ func (r *EndpointResource) Create(ctx context.Context, req resource.CreateReques
 			return
 		}
 		plan.Id = types.StringValue(res.Get("ERSEndPoint.id").String())
+		// Resolve the Optional+Computed profile_id from the existing object so it is
+		// known after apply (see the create branch above for rationale).
+		if value := res.Get("ERSEndPoint.profileId"); value.Exists() && value.String() != "" {
+			plan.ProfileId = types.StringValue(value.String())
+		} else {
+			plan.ProfileId = types.StringNull()
+		}
 		tflog.Debug(ctx, fmt.Sprintf("%s: Resource already exists, updating existing resource", plan.Id.ValueString()))
 		// Update existing object
 		body := plan.toBody(ctx, Endpoint{})

--- a/internal/provider/resource_ise_endpoint.go
+++ b/internal/provider/resource_ise_endpoint.go
@@ -95,7 +95,7 @@ func (r *EndpointResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
-					helpers.AdoptStateWhenSiblingBoolEquals("static_profile_assignment", false),
+					helpers.ComputedWhen("static_profile_assignment", false),
 				},
 			},
 			"static_profile_assignment": schema.BoolAttribute{


### PR DESCRIPTION
fix(endpoint): resolve profile_id ghost diff without freezing the field

Replace the blanket UseStateForUnknown on ise_endpoint.profile_id with a computed_when: static_profile_assignment=false plan modifier, so ISE's server-assigned value is preserved for dynamic endpoints (killing the UUID → null ghost diff on import) while operator-set values on static endpoints still plan normally and drift stays visible. The module should keep its profile_id line, so this provider fix stands alone. 