### PR TITLE
fix(ise): write custom_attributes as raw JSON in ise_internal_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
+- Fix `custom_attributes` in `ise_internal_user` being serialized as a quoted JSON string instead of a raw JSON object, causing ISE to reject create and update requests with HTTP 400; also fix perpetual drift caused by ISE returning pretty-printed JSON that did not match the compact form produced by `jsonencode`
 
 ## 0.3.4
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,6 +11,7 @@ description: |-
 
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
+- Fix `custom_attributes` in `ise_internal_user` being serialized as a quoted JSON string instead of a raw JSON object, causing ISE to reject create and update requests with HTTP 400; also fix perpetual drift caused by ISE returning pretty-printed JSON that did not match the compact form produced by `jsonencode`
 
 ## 0.3.4
 

--- a/gen/definitions/internal_user.yaml
+++ b/gen/definitions/internal_user.yaml
@@ -76,6 +76,7 @@ attributes:
     type: String
     description: Key value map
     normalize_empty_json: true
+    write_as_raw_json: true
     exclude_test: true
   - model_name: passwordIDStore
     data_path: [InternalUser]

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -146,6 +146,7 @@ type YamlConfigAttribute struct {
 	Immutable        bool                  `yaml:"immutable"`
 	WriteOnly        bool                  `yaml:"write_only"`
 	NormalizeEmptyJson   bool                  `yaml:"normalize_empty_json"`
+	WriteAsRawJson       bool                  `yaml:"write_as_raw_json"`
 	NormalizeEmptyString bool                  `yaml:"normalize_empty_string"`
 	PreserveEmptyString  bool                  `yaml:"preserve_empty_string"`
 	NormalizeOperator    bool                  `yaml:"normalize_operator"`

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -49,6 +49,7 @@ attribute:
   computed_when: str(required=False) # Conditional computed marker "<bool_attr>=<true|false>"; when the sibling Bool matches and this attribute is unset in config, keep the prior state value (conditional UseStateForUnknown, e.g. "static_profile_assignment=false")
   write_only: bool(required=False) # Set to true if the attribute is write-only, meaning we cannot read the value
   normalize_empty_json: bool(required=False) # Set to true to normalize an empty JSON object ({} or "{}") returned by the API to null, preventing drift when the config omits the attribute
+  write_as_raw_json: bool(required=False) # Set to true to write the string value as raw JSON (sjson.SetRaw) and read it back as compact JSON (CompactJson), for attributes that carry a JSON object stored as a string
   normalize_empty_string: bool(required=False) # Set to true to normalize an empty string ("") returned by the API to null, preventing drift when the config omits the attribute
   preserve_empty_string: bool(required=False) # Set to true to normalize null to empty string for mandatory fields that must contain "" when unset (opposite of normalize_empty_string)
   normalize_operator: bool(required=False) # Set to true to normalize IP-specific operator aliases (ipEquals -> equals, etc.) for stable key matching

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -380,7 +380,7 @@ func (data {{camelCase .Name}}) toBody(ctx context.Context, state {{camelCase .N
 	}
 	{{- else}}
 	if !data.{{toGoName .TfName}}.IsNull() {{if .ComputedWhen}}&& !data.{{toGoName .TfName}}.IsUnknown(){{end}}{{if .WriteChangesOnly}}&& data.{{toGoName .TfName}} != state.{{toGoName .TfName}}{{end}} {
-		body, _ = sjson.Set(body, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{if and (eq .Type "String") .NormalizeOperator}}helpers.NormalizeOperator(data.{{toGoName .TfName}}.ValueString()){{else}}data.{{toGoName .TfName}}.Value{{.Type}}(){{end}})
+		{{if and (eq .Type "String") .WriteAsRawJson}}body, _ = sjson.SetRaw(body, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", data.{{toGoName .TfName}}.ValueString()){{else}}body, _ = sjson.Set(body, "{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}", {{if and (eq .Type "String") .NormalizeOperator}}helpers.NormalizeOperator(data.{{toGoName .TfName}}.ValueString()){{else}}data.{{toGoName .TfName}}.Value{{.Type}}(){{end}}){{end}}
 	}
 	{{- end}}
 	{{- else if isListSet .}}
@@ -606,7 +606,7 @@ func (data *{{camelCase .Name}}) fromBody(ctx context.Context, res gjson.Result)
 	}
 	{{- else}}
 	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && value.Type != gjson.Null{{if .NormalizeEmptyJson}} && !((value.Type == gjson.JSON && len(value.Map()) == 0) || (value.Type == gjson.String && value.String() == "{}")){{end}}{{if .NormalizeEmptyString}} && value.String() != ""{{end}}{{if and (eq .Type "String") (not .DefaultValue) (hasComputedWhen $.Attributes)}} && value.String() != ""{{end}} {
-		data.{{toGoName .TfName}} = {{if and (eq .Type "String") .NormalizeOperator}}helpers.NewOperatorValue(helpers.NormalizeOperator(value.String())){{else}}types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}()){{end}}
+		data.{{toGoName .TfName}} = {{if and (eq .Type "String") .WriteAsRawJson}}types.StringValue(helpers.CompactJson(value.Raw)){{else if and (eq .Type "String") .NormalizeOperator}}helpers.NewOperatorValue(helpers.NormalizeOperator(value.String())){{else}}types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}()){{end}}
 	} else {
 		{{- if .DefaultValue}}
 		data.{{toGoName .TfName}} = types.{{.Type}}Value({{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}})
@@ -896,7 +896,7 @@ func (data *{{camelCase .Name}}) updateFromBody(ctx context.Context, res gjson.R
 	{{- if and (not .Value) (not .WriteOnly) (not .Reference)}}
 	{{- if or (eq .Type "String") (eq .Type "Int64") (eq .Type "Float64") (eq .Type "Bool")}}
 	if value := res.Get("{{if .ResponseDataPath}}{{.ResponseDataPath}}{{else}}{{if $openApi}}response.{{end}}{{range .DataPath}}{{.}}.{{end}}{{.ModelName}}{{end}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull(){{if .NormalizeEmptyJson}} && !((value.Type == gjson.JSON && len(value.Map()) == 0) || (value.Type == gjson.String && value.String() == "{}")){{end}}{{if .NormalizeEmptyString}} && value.String() != ""{{end}} {
-		data.{{toGoName .TfName}} = {{if and (eq .Type "String") .NormalizeOperator}}helpers.NewOperatorValue(helpers.NormalizeOperator(value.String())){{else}}types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}()){{end}}
+		data.{{toGoName .TfName}} = {{if and (eq .Type "String") .WriteAsRawJson}}types.StringValue(helpers.CompactJson(value.Raw)){{else if and (eq .Type "String") .NormalizeOperator}}helpers.NewOperatorValue(helpers.NormalizeOperator(value.String())){{else}}types.{{.Type}}Value(value.{{if eq .Type "Int64"}}Int{{else if eq .Type "Float64"}}Float{{else}}{{.Type}}{{end}}()){{end}}
 	} else {{if .DefaultValue}}if data.{{toGoName .TfName}}.Value{{.Type}}() != {{if eq .Type "String"}}"{{end}}{{.DefaultValue}}{{if eq .Type "String"}}"{{end}} {{end}}{
 		data.{{toGoName .TfName}} = {{goNullCtor .}}
 	}

--- a/internal/provider/helpers/utils.go
+++ b/internal/provider/helpers/utils.go
@@ -18,6 +18,9 @@
 package helpers
 
 import (
+	"bytes"
+	"encoding/json"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
@@ -92,6 +95,18 @@ func GetStringMapFiltered(apiResult map[string]gjson.Result, stateMap types.Map)
 		}
 	}
 	return types.MapValueMust(types.StringType, v)
+}
+
+// CompactJson normalizes a raw JSON string to compact form (no extra whitespace).
+// This prevents perpetual drift when an API returns pretty-printed JSON while
+// Terraform config uses jsonencode, which always produces compact JSON.
+// If the input is not valid JSON it is returned unchanged.
+func CompactJson(s string) string {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(s)); err != nil {
+		return s
+	}
+	return buf.String()
 }
 
 // NormalizeOperator maps ISE IP-specific operator variants to their standard

--- a/internal/provider/model_ise_internal_user.go
+++ b/internal/provider/model_ise_internal_user.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 
+	"github.com/CiscoDevNet/terraform-provider-ise/internal/provider/helpers"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -99,7 +100,7 @@ func (data InternalUser) toBody(ctx context.Context, state InternalUser) string 
 		body, _ = sjson.Set(body, "InternalUser.identityGroups", data.IdentityGroups.ValueString())
 	}
 	if !data.CustomAttributes.IsNull() {
-		body, _ = sjson.Set(body, "InternalUser.customAttributes", data.CustomAttributes.ValueString())
+		body, _ = sjson.SetRaw(body, "InternalUser.customAttributes", data.CustomAttributes.ValueString())
 	}
 	if !data.PasswordIdStore.IsNull() {
 		body, _ = sjson.Set(body, "InternalUser.passwordIDStore", data.PasswordIdStore.ValueString())
@@ -160,7 +161,7 @@ func (data *InternalUser) fromBody(ctx context.Context, res gjson.Result) {
 		data.IdentityGroups = types.StringNull()
 	}
 	if value := res.Get("InternalUser.customAttributes"); value.Exists() && value.Type != gjson.Null && !((value.Type == gjson.JSON && len(value.Map()) == 0) || (value.Type == gjson.String && value.String() == "{}")) {
-		data.CustomAttributes = types.StringValue(value.String())
+		data.CustomAttributes = types.StringValue(helpers.CompactJson(value.Raw))
 	} else {
 		data.CustomAttributes = types.StringNull()
 	}
@@ -226,7 +227,7 @@ func (data *InternalUser) updateFromBody(ctx context.Context, res gjson.Result) 
 		data.IdentityGroups = types.StringNull()
 	}
 	if value := res.Get("InternalUser.customAttributes"); value.Exists() && !data.CustomAttributes.IsNull() && !((value.Type == gjson.JSON && len(value.Map()) == 0) || (value.Type == gjson.String && value.String() == "{}")) {
-		data.CustomAttributes = types.StringValue(value.String())
+		data.CustomAttributes = types.StringValue(helpers.CompactJson(value.Raw))
 	} else {
 		data.CustomAttributes = types.StringNull()
 	}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -11,6 +11,7 @@ description: |-
 
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
+- Fix `custom_attributes` in `ise_internal_user` being serialized as a quoted JSON string instead of a raw JSON object, causing ISE to reject create and update requests with HTTP 400; also fix perpetual drift caused by ISE returning pretty-printed JSON that did not match the compact form produced by `jsonencode`
 
 ## 0.3.4
 


### PR DESCRIPTION
## Summary

Fixes #253

**Root cause 1 — HTTP 400 on create/update:** `toBody` used `sjson.Set` for `custom_attributes`, which encodes the Go string as a quoted JSON string. ISE requires a raw JSON object and rejects the quoted-string form with HTTP 400 `Resource Initialization Failed due to JSON invalidity`.

**Root cause 2 — Perpetual drift:** ISE returns `customAttributes` as pretty-printed JSON (e.g. `{ "Department" : "Engineering" }`), while callers using `jsonencode` produce compact JSON (`{"Department":"Engineering"}`). The whitespace difference caused Terraform to detect a change on every subsequent plan.

**Fix:** Adds a `write_as_raw_json` flag to the generator. When set on a `String` attribute, `toBody` uses `sjson.SetRaw` to embed the value as raw JSON rather than a quoted string. `fromBody` and `updateFromBody` use a new `helpers.CompactJson` helper to normalize ISE's pretty-printed response to compact form before storing in state.

## Changes

- `gen/generator.go` — add `WriteAsRawJson bool` field to `YamlConfigAttribute` struct
- `gen/templates/model.go` — use `sjson.SetRaw` in `toBody` and `helpers.CompactJson` in `fromBody`/`updateFromBody` when `write_as_raw_json` is set
- `gen/definitions/internal_user.yaml` — set `write_as_raw_json: true` on `customAttributes`
- `internal/provider/helpers/utils.go` — add `CompactJson` helper
- `internal/provider/model_ise_internal_user.go` — regenerated

## Test plan

**Pre-fix — HTTP 400 with quoted-string payload:**
```
Error: Client Error
Failed to configure object (POST), got error: HTTP Request failed: StatusCode 400,
Message: Resource Initialization Failed due to JSON invalidity
```

**Post-fix — create succeeds:**
```
module.ise.ise_internal_user.internal_user["BugTest_CustomAttr"]: Creating...
module.ise.ise_internal_user.internal_user["BugTest_CustomAttr"]: Creation complete after 0s [id=2b48bfe3-507d-4274-83f0-237cf0cdef4f]
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**Idempotency:**
```
No changes. Your infrastructure matches the configuration.
```

**Brownfield import + nac-test (9/9 passed):**
```
✅ All tests passed: 9 out of 9 tests
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Generator template changes, helper implementation, definition flag
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae