### PR TITLE
fix(ise): use IPV4/IPV6 enum values in network_access_dictionary_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.3.5 (unreleased)
 
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
+- Change the `data_type` enum values in the `ise_network_access_dictionary_attribute` resource from `UNIT64`, `IPv4` and `IPv6` to `UINT64`, `IPV4` and `IPV6` to match the ISE API and avoid HTTP 400 errors
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,8 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
+- Change the `data_type` enum values in the `ise_network_access_dictionary_attribute` resource from `UNIT64`, `IPv4` and `IPv6` to `UINT64`, `IPV4` and `IPV6` to match the ISE API and avoid HTTP 400 errors
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/docs/resources/network_access_dictionary_attribute.md
+++ b/docs/resources/network_access_dictionary_attribute.md
@@ -35,7 +35,7 @@ resource "ise_network_access_dictionary_attribute" "example" {
 ### Required
 
 - `data_type` (String) The data type for the dictionary attribute
-  - Choices: `BOOLEAN`, `DATE`, `FLOAT`, `INT`, `IP`, `IPv4`, `IPv6`, `IPV6PREFIX`, `LONG`, `OCTET_STRING`, `STRING`, `UNIT32`, `UNIT64`
+  - Choices: `BOOLEAN`, `DATE`, `FLOAT`, `INT`, `IP`, `IPV4`, `IPV6`, `IPV6PREFIX`, `LONG`, `OCTET_STRING`, `STRING`, `UNIT32`, `UNIT64`
 - `dictionary_name` (String) The name of the dictionary the attribute belongs to
 - `name` (String) The dictionary attribute name
 

--- a/gen/definitions/network_access_dictionary_attribute.yaml
+++ b/gen/definitions/network_access_dictionary_attribute.yaml
@@ -27,7 +27,7 @@ attributes:
   - model_name: dataType
     type: String
     mandatory: true
-    enum_values: [BOOLEAN, DATE, FLOAT, INT, IP, IPv4, IPv6, IPV6PREFIX, LONG, OCTET_STRING, STRING, UNIT32, UNIT64]
+    enum_values: [BOOLEAN, DATE, FLOAT, INT, IP, IPV4, IPV6, IPV6PREFIX, LONG, OCTET_STRING, STRING, UNIT32, UNIT64]
     description: The data type for the dictionary attribute
     example: STRING
   - model_name: directionType

--- a/internal/provider/resource_ise_network_access_dictionary_attribute.go
+++ b/internal/provider/resource_ise_network_access_dictionary_attribute.go
@@ -94,10 +94,10 @@ func (r *NetworkAccessDictionaryAttributeResource) Schema(ctx context.Context, r
 				Optional:            true,
 			},
 			"data_type": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64").String,
+				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPV4", "IPV6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64").String,
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64"),
+					stringvalidator.OneOf("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPV4", "IPV6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64"),
 				},
 			},
 			"direction_type": schema.StringAttribute{

--- a/internal/provider/resource_ise_network_access_dictionary_attribute.go
+++ b/internal/provider/resource_ise_network_access_dictionary_attribute.go
@@ -94,7 +94,7 @@ func (r *NetworkAccessDictionaryAttributeResource) Schema(ctx context.Context, r
 				Optional:            true,
 			},
 			"data_type": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UINT64").String,
+				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPV4", "IPV6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UINT64").String,
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPV4", "IPV6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UINT64"),

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,8 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
-- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
+- Change the `data_type` enum values in the `ise_network_access_dictionary_attribute` resource from `UNIT64`, `IPv4` and `IPv6` to `UINT64`, `IPV4` and `IPV6` to match the ISE API and avoid HTTP 400 errors
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `IPv4`/`IPv6` but ISE only accepts `IPV4`/`IPV6`; update the valid values to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 


### PR DESCRIPTION
## Summary

Fixes #255

**Root cause:** ISE's OpenAPI endpoint only accepts and returns `IPV4` and `IPV6` (all caps) for the `dataType` field. The provider schema listed `IPv4` and `IPv6` (mixed case), causing every create or update with these values to fail with HTTP 400.

**Impact:** These values have never worked since the resource was added.

**Fix:** Update the enum values in the definition file to match the ISE API exactly.

## Broken configuration

```yaml
ise:
  network_access:
    policy_elements:
      dictionaries:
        - name: CustomDict
          version: "1.0"
          attribute_type: ENTITY_ATTR
          attributes:
            - name: TestAttr
              data_type: IPv4    # HTTP 400 — ISE rejects this
```

## Fixed configuration

```yaml
ise:
  network_access:
    policy_elements:
      dictionaries:
        - name: CustomDict
          version: "1.0"
          attribute_type: ENTITY_ATTR
          attributes:
            - name: TestAttr
              data_type: IPV4    # correct — matches the ISE API
```

## Changes

- `gen/definitions/network_access_dictionary_attribute.yaml` — replace `IPv4`/`IPv6` with `IPV4`/`IPV6` in `enum_values`
- `internal/provider/resource_ise_network_access_dictionary_attribute.go` — regenerated: validator now accepts `IPV4`/`IPV6`
- `docs/resources/network_access_dictionary_attribute.md` — regenerated: docs updated to show `IPV4`/`IPV6`

## Test plan

**Before fix** — `terraform apply` with `data_type = "IPv4"`:
```
Error: Client Error
  with module.ise.ise_network_access_dictionary_attribute.network_access_dictionary_attribute["Bug5TestDict/TestIPv4Attr"]

Failed to configure object (POST), got error: HTTP Request failed:
StatusCode 400, Message: , {
  "message" : "Failed to handle HTTP API: JSON parse error: Cannot construct instance of
  `com.cisco.cpm.iseopenapi.policy.model.DictionaryAttribute$DataTypeEnum`,
  problem: Unexpected value 'IPv4'...",
  "code" : 400
}
```

**After fix** — `terraform apply` with `data_type = "IPV4"`:
```
module.ise.ise_network_access_dictionary.network_access_dictionary["Bug5TestDict"]: Creation complete after 0s [id=Bug5TestDict]
module.ise.ise_network_access_dictionary_attribute.network_access_dictionary_attribute["Bug5TestDict/TestIPv4Attr"]: Creation complete after 0s [id=TestIPv4Attr]
```

`terraform plan` immediately after (idempotency):
```
Plan: 0 to add, 0 to change, 0 to destroy.
```

Tested against ISE 3.4.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, fix identification, and code generation
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae