### PR TITLE
fix(ise): use UINT64 enum value in network_access_dictionary_attribute data_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 

--- a/docs/resources/network_access_dictionary_attribute.md
+++ b/docs/resources/network_access_dictionary_attribute.md
@@ -35,7 +35,7 @@ resource "ise_network_access_dictionary_attribute" "example" {
 ### Required
 
 - `data_type` (String) The data type for the dictionary attribute
-  - Choices: `BOOLEAN`, `DATE`, `FLOAT`, `INT`, `IP`, `IPv4`, `IPv6`, `IPV6PREFIX`, `LONG`, `OCTET_STRING`, `STRING`, `UNIT32`, `UNIT64`
+  - Choices: `BOOLEAN`, `DATE`, `FLOAT`, `INT`, `IP`, `IPv4`, `IPv6`, `IPV6PREFIX`, `LONG`, `OCTET_STRING`, `STRING`, `UNIT32`, `UINT64`
 - `dictionary_name` (String) The name of the dictionary the attribute belongs to
 - `name` (String) The dictionary attribute name
 

--- a/gen/definitions/network_access_dictionary_attribute.yaml
+++ b/gen/definitions/network_access_dictionary_attribute.yaml
@@ -27,7 +27,7 @@ attributes:
   - model_name: dataType
     type: String
     mandatory: true
-    enum_values: [BOOLEAN, DATE, FLOAT, INT, IP, IPv4, IPv6, IPV6PREFIX, LONG, OCTET_STRING, STRING, UNIT32, UNIT64]
+    enum_values: [BOOLEAN, DATE, FLOAT, INT, IP, IPv4, IPv6, IPV6PREFIX, LONG, OCTET_STRING, STRING, UNIT32, UINT64]
     description: The data type for the dictionary attribute
     example: STRING
   - model_name: directionType

--- a/internal/provider/resource_ise_network_access_dictionary_attribute.go
+++ b/internal/provider/resource_ise_network_access_dictionary_attribute.go
@@ -94,10 +94,10 @@ func (r *NetworkAccessDictionaryAttributeResource) Schema(ctx context.Context, r
 				Optional:            true,
 			},
 			"data_type": schema.StringAttribute{
-				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64").String,
+				MarkdownDescription: helpers.NewAttributeDescription("The data type for the dictionary attribute").AddStringEnumDescription("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UINT64").String,
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.OneOf("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UNIT64"),
+					stringvalidator.OneOf("BOOLEAN", "DATE", "FLOAT", "INT", "IP", "IPv4", "IPv6", "IPV6PREFIX", "LONG", "OCTET_STRING", "STRING", "UNIT32", "UINT64"),
 				},
 			},
 			"direction_type": schema.StringAttribute{

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -9,6 +9,7 @@ description: |-
 
 ## 0.3.5 (unreleased)
 
+- Fix HTTP 400 errors in `ise_network_access_dictionary_attribute` where the `data_type` attribute accepted `UNIT64` but ISE only accepts `UINT64`; update the valid value to match the ISE API
 - Fix perpetual drift in the `group_id` and `profile_id` attributes of the `ise_endpoint` resource, where ISE dynamically assigns these values when `static_group_assignment` / `static_profile_assignment` are `false`, causing Terraform to report changes on every plan
 - Fix perpetual drift after importing existing (brownfield) resources, where ISE returns normalized values for policy condition operators (e.g. `ipEquals` for `equals`) and empty strings for unset optional fields such as `description`, causing Terraform to report changes on every plan
 


### PR DESCRIPTION
## Summary

Fixes #257

**Root cause:** The provider enum for `data_type` in `ise_network_access_dictionary_attribute` included `UNIT64` (missing the letter 'I'), but ISE's OpenAPI endpoint only accepts and returns `UINT64`. Every create or update with `data_type = "UNIT64"` has always failed with HTTP 400 since the resource was added.

**Note:** `UNIT32` is intentionally unchanged — ISE uses `UNIT32` (not `UINT32`) for the 32-bit type. Only the 64-bit value is affected.

**Fix:** Change `UNIT64` to `UINT64` in the enum values to match the ISE API.

## Broken configuration

```yaml
ise:
  network_access:
    policy_elements:
      dictionaries:
        - name: CustomDict
          version: "1.0"
          attribute_type: ENTITY_ATTR
          attributes:
            - name: TestAttr
              data_type: UNIT64    # HTTP 400 — ISE rejects this value
```

## Fixed configuration

```yaml
ise:
  network_access:
    policy_elements:
      dictionaries:
        - name: CustomDict
          version: "1.0"
          attribute_type: ENTITY_ATTR
          attributes:
            - name: TestAttr
              data_type: UINT64    # correct — matches the ISE API
```

## Changes

- `gen/definitions/network_access_dictionary_attribute.yaml` — change `UNIT64` to `UINT64` in `enum_values`
- `internal/provider/resource_ise_network_access_dictionary_attribute.go` — regenerated: validator now accepts `UINT64`
- `docs/resources/network_access_dictionary_attribute.md` — regenerated: docs updated to show `UINT64`

## Test plan

**Before fix** — `terraform apply` with `data_type = "UNIT64"`:
```
Error: Client Error
  with module.ise.ise_network_access_dictionary_attribute.network_access_dictionary_attribute["Bug6TestDict/TestUINT64Attr"]

Failed to configure object (POST), got error: HTTP Request failed:
StatusCode 400, Message: , {
  "message" : "Failed to handle HTTP API: JSON parse error: Cannot construct instance of
  `com.cisco.cpm.iseopenapi.policy.model.DictionaryAttribute$DataTypeEnum`,
  problem: Unexpected value 'UNIT64'...",
  "code" : 400
}
```

**After fix** — `terraform apply` with `data_type = "UINT64"`:
```
module.ise.ise_network_access_dictionary.network_access_dictionary["Bug6TestDict"]: Creation complete after 0s [id=Bug6TestDict]
module.ise.ise_network_access_dictionary_attribute.network_access_dictionary_attribute["Bug6TestDict/TestUINT64Attr"]: Creation complete after 0s [id=TestUINT64Attr]
```

`terraform plan` immediately after (idempotency):
```
Plan: 0 to add, 0 to change, 0 to destroy.
```

Tested against ISE 3.4.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, fix identification, and code generation
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae