### PR TITLE
fix(ise): allow snmp_polling_interval of 0 on ise_network_device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1 (unreleased)
+
+- Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+
 ## 0.4.0
 
 - Change the `custom_attributes` attribute of the `ise_internal_user` resource from a JSON-encoded `String` to a `Map` of strings, fixing an HTTP 400 on apply (the value was serialized as a quoted string that ISE rejected) and perpetual drift (string comparison was sensitive to whitespace and key ordering). This matches how `ise_endpoint` already models its `custom_attributes`. **Breaking change:** configurations must now supply a native map (`custom_attributes = { key = "value" }`) instead of `jsonencode({ ... })` [link](https://github.com/CiscoDevNet/terraform-provider-ise/issues/253)

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.4.1 (unreleased)
+
+- Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+
 ## 0.4.0
 
 - Change the `custom_attributes` attribute of the `ise_internal_user` resource from a JSON-encoded `String` to a `Map` of strings, fixing an HTTP 400 on apply (the value was serialized as a quoted string that ISE rejected) and perpetual drift (string comparison was sensitive to whitespace and key ordering). This matches how `ise_endpoint` already models its `custom_attributes`. **Breaking change:** configurations must now supply a native map (`custom_attributes = { key = "value" }`) instead of `jsonencode({ ... })` [link](https://github.com/CiscoDevNet/terraform-provider-ise/issues/253)

--- a/docs/resources/network_device.md
+++ b/docs/resources/network_device.md
@@ -102,7 +102,7 @@ resource "ise_network_device" "example" {
 - `snmp_mac_trap_query` (Boolean) SNMP MAC Trap Query
 - `snmp_originating_policy_service_node` (String) Originating Policy Services Node
 - `snmp_polling_interval` (Number) SNMP Polling Interval in seconds
-  - Range: `600`-`86400`
+  - Range: `0` (disabled) or `600`-`86400`
 - `snmp_privacy_password` (String) SNMP privacy password. Required for snmp version 3 and securityLevel PRIV
 - `snmp_privacy_protocol` (String) SNMP privacy protocol. Required for snmp version 3 and securityLevel PRIV.
   - Choices: `DES`, `AES128`, `AES192`, `AES256`, `3DES`

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -157,6 +157,7 @@ attributes:
     type: Int64
     min_int: 600
     max_int: 86400
+    zero_allowed: true
     description: SNMP Polling Interval in seconds
     example: 1200
   - model_name: roCommunity

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -158,6 +158,7 @@ attributes:
     min_int: 600
     max_int: 86400
     zero_allowed: true
+    zero_allowed_description: disabled
     description: SNMP Polling Interval in seconds
     example: 1200
   - model_name: roCommunity

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -161,6 +161,7 @@ type YamlConfigAttribute struct {
 	MaxList          int64                 `yaml:"max_list"`
 	MinInt           int64                 `yaml:"min_int"`
 	MaxInt           int64                 `yaml:"max_int"`
+	ZeroAllowed      bool                  `yaml:"zero_allowed"`
 	MinFloat         float64               `yaml:"min_float"`
 	MaxFloat         float64               `yaml:"max_float"`
 	StringPatterns   []string              `yaml:"string_patterns"`

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -161,7 +161,8 @@ type YamlConfigAttribute struct {
 	MaxList          int64                 `yaml:"max_list"`
 	MinInt           int64                 `yaml:"min_int"`
 	MaxInt           int64                 `yaml:"max_int"`
-	ZeroAllowed      bool                  `yaml:"zero_allowed"`
+	ZeroAllowed            bool                  `yaml:"zero_allowed"`
+	ZeroAllowedDescription string                `yaml:"zero_allowed_description"`
 	MinFloat         float64               `yaml:"min_float"`
 	MaxFloat         float64               `yaml:"max_float"`
 	StringPatterns   []string              `yaml:"string_patterns"`

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -63,6 +63,7 @@ attribute:
   max_list: int(required=False) # Maximum number of elements in a list, only relevant if type is "List"
   min_int: int(required=False) # Minimum value of an integer, only relevant if type is "Int64"
   max_int: int(required=False) # Maximum value of an integer, only relevant if type is "Int64"
+  zero_allowed: bool(required=False) # Allow 0 as a sentinel "disabled" value in addition to the min_int-max_int range, only relevant if type is "Int64"
   min_float: num(required=False) # Minimum value of a float, only relevant if type is "Float"
   max_float: num(required=False) # Maximum value of a float, only relevant if type is "Float"
   string_patterns: list(str(), required=False) # List of regular expressions that the string must match, only relevant if type is "String"

--- a/gen/schema/schema.yaml
+++ b/gen/schema/schema.yaml
@@ -63,7 +63,8 @@ attribute:
   max_list: int(required=False) # Maximum number of elements in a list, only relevant if type is "List"
   min_int: int(required=False) # Minimum value of an integer, only relevant if type is "Int64"
   max_int: int(required=False) # Maximum value of an integer, only relevant if type is "Int64"
-  zero_allowed: bool(required=False) # Allow 0 as a sentinel "disabled" value in addition to the min_int-max_int range, only relevant if type is "Int64"
+  zero_allowed: bool(required=False) # Allow 0 as a sentinel value in addition to the min_int-max_int range, only relevant if type is "Int64"
+  zero_allowed_description: str(required=False) # Human-readable label for 0 shown in the range description (e.g. "disabled", "unlimited"); should be set whenever zero_allowed is true
   min_float: num(required=False) # Minimum value of a float, only relevant if type is "Float"
   max_float: num(required=False) # Maximum value of a float, only relevant if type is "Float"
   string_patterns: list(str(), required=False) # List of regular expressions that the string must match, only relevant if type is "String"

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -97,7 +97,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 					.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 					{{- end -}}
 					{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-					.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+					{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 					{{- end -}}
 					{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 					.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -176,7 +176,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 								.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 								{{- end -}}
 								{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-								.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+								{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 								{{- end -}}
 								{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 								.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -251,7 +251,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 											.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 											{{- end -}}
 											{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-											.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+											{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 											{{- end -}}
 											{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 											.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -326,7 +326,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 														.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 														{{- end -}}
 														{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-														.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+														{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 														{{- end -}}
 														{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 														.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -401,7 +401,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																	.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																	{{- end -}}
 																	{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																	.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+																	{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 																	{{- end -}}
 																	{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																	.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -476,7 +476,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																				.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																				{{- end -}}
 																				{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																				.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+																				{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 																				{{- end -}}
 																				{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																				.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -551,7 +551,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																						.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																						{{- end -}}
 																						{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																						.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
+																						{{if .ZeroAllowed}}.AddZeroOrIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}, "{{.ZeroAllowedDescription}}"){{else}}.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}}){{end}}
 																						{{- end -}}
 																						{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																						.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -97,7 +97,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 					.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 					{{- end -}}
 					{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-					.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+					.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 					{{- end -}}
 					{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 					.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -137,7 +137,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 				},
 				{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 				Validators: []validator.Int64{
-					int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+					{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 				},
 				{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 				Validators: []validator.Float64{
@@ -176,7 +176,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 								.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 								{{- end -}}
 								{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-								.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+								.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 								{{- end -}}
 								{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 								.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -216,7 +216,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 							},
 							{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 							Validators: []validator.Int64{
-								int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+								{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 							},
 							{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 							Validators: []validator.Float64{
@@ -251,7 +251,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 											.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 											{{- end -}}
 											{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-											.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+											.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 											{{- end -}}
 											{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 											.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -291,7 +291,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 										},
 										{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 										Validators: []validator.Int64{
-											int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+											{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 										},
 										{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 										Validators: []validator.Float64{
@@ -326,7 +326,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 														.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 														{{- end -}}
 														{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-														.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+														.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 														{{- end -}}
 														{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 														.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -366,7 +366,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 													},
 													{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 													Validators: []validator.Int64{
-														int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+														{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 													},
 													{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 													Validators: []validator.Float64{
@@ -401,7 +401,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																	.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																	{{- end -}}
 																	{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																	.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+																	.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 																	{{- end -}}
 																	{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																	.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -441,7 +441,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																},
 																{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 																Validators: []validator.Int64{
-																	int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+																	{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 																},
 																{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 																Validators: []validator.Float64{
@@ -476,7 +476,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																				.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																				{{- end -}}
 																				{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																				.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+																				.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 																				{{- end -}}
 																				{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																				.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -516,7 +516,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																			},
 																			{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 																			Validators: []validator.Int64{
-																				int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+																				{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 																			},
 																			{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 																			Validators: []validator.Float64{
@@ -551,7 +551,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																						.AddStringEnumDescription({{range .EnumValues}}"{{.}}", {{end}})
 																						{{- end -}}
 																						{{- if or (ne .MinInt 0) (ne .MaxInt 0) -}}
-																						.AddIntegerRangeDescription({{.MinInt}}, {{.MaxInt}})
+																						.{{if .ZeroAllowed}}AddZeroOrIntegerRangeDescription{{else}}AddIntegerRangeDescription{{end}}({{.MinInt}}, {{.MaxInt}})
 																						{{- end -}}
 																						{{- if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0) -}}
 																						.AddFloatRangeDescription({{.MinFloat}}, {{.MaxFloat}})
@@ -591,7 +591,7 @@ func (r *{{camelCase .Name}}Resource) Schema(ctx context.Context, req resource.S
 																					},
 																					{{- else if or (ne .MinInt 0) (ne .MaxInt 0)}}
 																					Validators: []validator.Int64{
-																						int64validator.Between({{.MinInt}}, {{.MaxInt}}),
+																						{{if .ZeroAllowed}}int64validator.Any(int64validator.OneOf(0), int64validator.Between({{.MinInt}}, {{.MaxInt}})),{{else}}int64validator.Between({{.MinInt}}, {{.MaxInt}}),{{end}}
 																					},
 																					{{- else if or (ne .MinFloat 0.0) (ne .MaxFloat 0.0)}}
 																					Validators: []validator.Float64{

--- a/internal/provider/helpers/description_builder.go
+++ b/internal/provider/helpers/description_builder.go
@@ -54,6 +54,11 @@ func (d *AttributeDescription) AddIntegerRangeDescription(min, max int64) *Attri
 	return d
 }
 
+func (d *AttributeDescription) AddZeroOrIntegerRangeDescription(min, max int64) *AttributeDescription {
+	d.String = fmt.Sprintf("%s\n  - Range: `0` (disabled) or `%v`-`%v`", d.String, min, max)
+	return d
+}
+
 func (d *AttributeDescription) AddFloatRangeDescription(min, max float64) *AttributeDescription {
 	d.String = fmt.Sprintf("%s\n  - Range: `%v`-`%v`", d.String, min, max)
 	return d

--- a/internal/provider/helpers/description_builder.go
+++ b/internal/provider/helpers/description_builder.go
@@ -54,8 +54,8 @@ func (d *AttributeDescription) AddIntegerRangeDescription(min, max int64) *Attri
 	return d
 }
 
-func (d *AttributeDescription) AddZeroOrIntegerRangeDescription(min, max int64) *AttributeDescription {
-	d.String = fmt.Sprintf("%s\n  - Range: `0` (disabled) or `%v`-`%v`", d.String, min, max)
+func (d *AttributeDescription) AddZeroOrIntegerRangeDescription(min, max int64, label string) *AttributeDescription {
+	d.String = fmt.Sprintf("%s\n  - Range: `0` (%s) or `%v`-`%v`", d.String, label, min, max)
 	return d
 }
 

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -190,10 +190,10 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:            true,
 			},
 			"snmp_polling_interval": schema.Int64Attribute{
-				MarkdownDescription: helpers.NewAttributeDescription("SNMP Polling Interval in seconds").AddIntegerRangeDescription(600, 86400).String,
+				MarkdownDescription: helpers.NewAttributeDescription("SNMP Polling Interval in seconds").AddZeroOrIntegerRangeDescription(600, 86400).String,
 				Optional:            true,
 				Validators: []validator.Int64{
-					int64validator.Between(600, 86400),
+					int64validator.Any(int64validator.OneOf(0), int64validator.Between(600, 86400)),
 				},
 			},
 			"snmp_ro_community": schema.StringAttribute{

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -190,7 +190,7 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:            true,
 			},
 			"snmp_polling_interval": schema.Int64Attribute{
-				MarkdownDescription: helpers.NewAttributeDescription("SNMP Polling Interval in seconds").AddZeroOrIntegerRangeDescription(600, 86400).String,
+				MarkdownDescription: helpers.NewAttributeDescription("SNMP Polling Interval in seconds").AddZeroOrIntegerRangeDescription(600, 86400, "disabled").String,
 				Optional:            true,
 				Validators: []validator.Int64{
 					int64validator.Any(int64validator.OneOf(0), int64validator.Between(600, 86400)),

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,10 @@ description: |-
 
 # Changelog
 
+## 0.4.1 (unreleased)
+
+- Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+
 ## 0.4.0
 
 - Change the `custom_attributes` attribute of the `ise_internal_user` resource from a JSON-encoded `String` to a `Map` of strings, fixing an HTTP 400 on apply (the value was serialized as a quoted string that ISE rejected) and perpetual drift (string comparison was sensitive to whitespace and key ordering). This matches how `ise_endpoint` already models its `custom_attributes`. **Breaking change:** configurations must now supply a native map (`custom_attributes = { key = "value" }`) instead of `jsonencode({ ... })` [link](https://github.com/CiscoDevNet/terraform-provider-ise/issues/253)


### PR DESCRIPTION
## Summary

Fixes #263

**Root cause:** The `snmp_polling_interval` attribute used `min_int: 600` in the generator definition, producing `int64validator.Between(600, 86400)`. This rejects `0`, which is a valid ISE value meaning "SNMP polling disabled". ISE accepts `pollingInterval: 0` on POST/PUT and returns it unchanged on GET; values 1–599 are rejected by ISE itself with HTTP 400.

**Impact:** Any network device with SNMP credentials configured but polling disabled (`pollingInterval: 0`) fails at `terraform plan` with a provider-side validation error before any API call is made.

**Fix:** The generator only supported a single `Between()` validator via `min_int`/`max_int`. A new `zero_allowed: bool` field is added to the generator that emits `int64validator.Any(int64validator.OneOf(0), int64validator.Between(min, max))` instead, precisely matching ISE's actual constraint. The `AddZeroOrIntegerRangeDescription` helper is also added so the Terraform Registry docs correctly describe the valid range as `0 (disabled) or 600–86400`.

## Changes

- `gen/generator.go` — Add `ZeroAllowed bool` field to `YamlConfigAttribute` struct
- `gen/schema/schema.yaml` — Declare `zero_allowed` as a valid definition field
- `gen/templates/resource.go` — Emit `int64validator.Any(...)` when `zero_allowed: true`, and call `AddZeroOrIntegerRangeDescription` for the markdown description (applied at all 7 nesting levels via `replace_all`)
- `internal/provider/helpers/description_builder.go` — Add `AddZeroOrIntegerRangeDescription` helper
- `gen/definitions/network_device.yaml` — Set `zero_allowed: true` on `pollingInterval`
- `internal/provider/resource_ise_network_device.go` — Regenerated: validator is now `int64validator.Any(int64validator.OneOf(0), int64validator.Between(600, 86400))`
- `docs/resources/network_device.md` — Regenerated: range shown as `0 (disabled) or 600-86400`

## Test plan

**YAML configuration used to reproduce and verify:**

```yaml
ise:
  network_resources:
    network_devices:
      - name: TestDeviceSNMPDisabled
        ips:
          - ip: 192.0.2.1
            mask: 32
        snmp:
          version: TWO_C
          ro_community: public
          polling_interval: 0
```

**Before (ISE 3.4, provider built from main):**
```
Error: Invalid Attribute Value
  with module.ise.ise_network_device.network_device["TestDeviceSNMPDisabled"],
  on ../ise/terraform-ise-nac-ise/ise_network_resources.tf line 200
  Attribute snmp_polling_interval value must be between 600 and 86400, got: 0
```

**After (provider built from this branch):**

`terraform plan`:
```
# module.ise.ise_network_device.network_device["TestDeviceSNMPDisabled"] will be created
+ resource "ise_network_device" "network_device" {
    + snmp_polling_interval = 0
    + snmp_ro_community     = "public"
    + snmp_version          = "TWO_C"
    ...
  }
Plan: 1 to add, 0 to change, 0 to destroy.
```

`terraform apply`: `Creation complete after 1s [id=cb1f2680-9c02-11f1-9a32-468f9ffca84d]`

`terraform plan` (idempotency): `No changes. Your infrastructure matches the configuration.`

ISE API confirmed `pollingInterval: 0` accepted on POST (HTTP 201) and returned unchanged on GET. Values 1–599 rejected by ISE with HTTP 400.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Generator extension, template changes, definition update, and full test cycle
- **Human Oversight**: Code reviewed, tested against live ISE 3.4 node, and approved by camschae