### PR TITLE
fix(ise_network_device): remove Default(1700) from coa_port to prevent perpetual drift on TACACS-only devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add `ise_sxp_connection`, `ise_sxp_vpn` and `ise_sxp_local_binding` resources and data sources
 - Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+- Fix perpetual `coa_port = 0 -> 1700` drift on the `ise_network_device` resource for TACACS-only devices. The `coa_port` attribute had a provider-level `Default(1700)` and `Computed: true` that resolved a null config value to `1700` at plan time, causing drift whenever ISE reported `coaPort: 0` (no CoA configured). Removing the schema default makes `coa_port` behave like all other optional RADIUS attributes on this resource — if not set in config, ISE retains its current value and no plan diff is generated.
 
 ## 0.4.0
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -11,6 +11,7 @@ description: |-
 
 - Add `ise_sxp_connection`, `ise_sxp_vpn` and `ise_sxp_local_binding` resources and data sources
 - Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+- Fix perpetual `coa_port = 0 -> 1700` drift on the `ise_network_device` resource for TACACS-only devices. The `coa_port` attribute had a provider-level `Default(1700)` and `Computed: true` that resolved a null config value to `1700` at plan time, causing drift whenever ISE reported `coaPort: 0` (no CoA configured). Removing the schema default makes `coa_port` behave like all other optional RADIUS attributes on this resource — if not set in config, ISE retains its current value and no plan diff is generated.
 
 ## 0.4.0
 

--- a/docs/resources/network_device.md
+++ b/docs/resources/network_device.md
@@ -88,7 +88,6 @@ resource "ise_network_device" "example" {
 - `authentication_radius_shared_secret` (String) RADIUS shared secret
 - `authentication_second_radius_shared_secret` (String) Second RADIUS shared secret
 - `coa_port` (Number) CoA port
-  - Default value: `1700`
 - `description` (String) Description
 - `dtls_dns_name` (String) This value is used to verify the client identity contained in the X.509 RADIUS/DTLS client certificate
 - `model_name` (String) Model name

--- a/gen/definitions/network_device.yaml
+++ b/gen/definitions/network_device.yaml
@@ -79,7 +79,6 @@ attributes:
     data_path: [NetworkDevice]
     type: Int64
     description: CoA port
-    default_value: 1700
     example: 12345
   - model_name: dtlsDnsName
     data_path: [NetworkDevice]

--- a/internal/provider/model_ise_network_device.go
+++ b/internal/provider/model_ise_network_device.go
@@ -333,7 +333,7 @@ func (data *NetworkDevice) fromBody(ctx context.Context, res gjson.Result) {
 	if value := res.Get("NetworkDevice.coaPort"); value.Exists() && value.Type != gjson.Null {
 		data.CoaPort = types.Int64Value(value.Int())
 	} else {
-		data.CoaPort = types.Int64Value(1700)
+		data.CoaPort = types.Int64Null()
 	}
 	if value := res.Get("NetworkDevice.dtlsDnsName"); value.Exists() && value.Type != gjson.Null {
 		data.DtlsDnsName = types.StringValue(value.String())
@@ -591,7 +591,7 @@ func (data *NetworkDevice) updateFromBody(ctx context.Context, res gjson.Result)
 	}
 	if value := res.Get("NetworkDevice.coaPort"); value.Exists() && !data.CoaPort.IsNull() {
 		data.CoaPort = types.Int64Value(value.Int())
-	} else if data.CoaPort.ValueInt64() != 1700 {
+	} else {
 		data.CoaPort = types.Int64Null()
 	}
 	if value := res.Get("NetworkDevice.dtlsDnsName"); value.Exists() && !data.DtlsDnsName.IsNull() {

--- a/internal/provider/resource_ise_network_device.go
+++ b/internal/provider/resource_ise_network_device.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -129,10 +128,8 @@ func (r *NetworkDeviceResource) Schema(ctx context.Context, req resource.SchemaR
 				Optional:            true,
 			},
 			"coa_port": schema.Int64Attribute{
-				MarkdownDescription: helpers.NewAttributeDescription("CoA port").AddDefaultValueDescription("1700").String,
+				MarkdownDescription: helpers.NewAttributeDescription("CoA port").String,
 				Optional:            true,
-				Computed:            true,
-				Default:             int64default.StaticInt64(1700),
 			},
 			"dtls_dns_name": schema.StringAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("This value is used to verify the client identity contained in the X.509 RADIUS/DTLS client certificate").String,

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -11,6 +11,7 @@ description: |-
 
 - Add `ise_sxp_connection`, `ise_sxp_vpn` and `ise_sxp_local_binding` resources and data sources
 - Fix `snmp_polling_interval` on the `ise_network_device` resource rejecting `0`, which is a valid ISE value meaning "SNMP polling disabled". The validator now accepts `0` (disabled) or `600`-`86400` (enabled), matching ISE's actual constraint. The generator was also extended with a `zero_allowed` field for other attributes that follow this "sentinel or range" pattern.
+- Fix perpetual `coa_port = 0 -> 1700` drift on the `ise_network_device` resource for TACACS-only devices. The `coa_port` attribute had a provider-level `Default(1700)` and `Computed: true` that resolved a null config value to `1700` at plan time, causing drift whenever ISE reported `coaPort: 0` (no CoA configured). Removing the schema default makes `coa_port` behave like all other optional RADIUS attributes on this resource — if not set in config, ISE retains its current value and no plan diff is generated.
 
 ## 0.4.0
 


### PR DESCRIPTION
## Summary

Fixes #267

**Root cause:** The `coa_port` attribute was defined with `Computed: true` and `Default: int64default.StaticInt64(1700)`. When `coa_port` is absent from the Terraform configuration (null), the schema Default resolved it to `1700` at plan time. For network devices imported with `coaPort: 0` in ISE (TACACS-only devices with no CoA configured), this produced perpetual `coa_port = 0 -> 1700` drift on every `terraform plan`, even when `coa_port` was not set in the configuration.

**Impact:** Any deployment that imports network devices where ISE reports `coaPort: 0` sees perpetual plan drift.

**Fix:** Remove `default_value: 1700` from `gen/definitions/network_device.yaml` and regenerate. The `coa_port` attribute is now `Optional` only, consistent with all other optional RADIUS attributes on this resource (`authentication_enable_key_wrap`, `authentication_dtls_required`, `authentication_encryption_key_format`, etc.). When `coa_port` is not set in config, the provider omits it from the API call and ISE retains its current value — no drift.

## Changes

- `gen/definitions/network_device.yaml` — removed `default_value: 1700` from `coaPort` attribute
- `internal/provider/resource_ise_network_device.go` — regenerated: removed `Computed: true`, `Default: int64default.StaticInt64(1700)`, and `AddDefaultValueDescription("1700")`
- `internal/provider/model_ise_network_device.go` — regenerated: `fromBody` fallback changed from `types.Int64Value(1700)` to `types.Int64Null()`; `updateFromBody` guard `else if CoaPort != 1700` simplified to `else`
- `docs/resources/network_device.md` — regenerated: removed `Default value: 1700` from `coa_port` attribute description

## Test plan

Tested against a live ISE node using a TACACS-only network device with `coaPort: 0`. Before fix:

```
~ coa_port = 0 -> 1700   # perpetual drift on every plan
```

After fix — `terraform plan` for the same imported device shows:

```
No changes. Your infrastructure matches the configuration.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, definition file fix, regeneration, and PR authoring
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae